### PR TITLE
feat: add branch protection rules for main (#95)

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -1,0 +1,45 @@
+name: Apply Branch Protection
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/branch-protection.yml"
+
+jobs:
+  protect:
+    name: Enforce main branch protection
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      administration: write
+    steps:
+      - name: Apply branch protection rules
+        env:
+          GH_TOKEN: ${{ secrets.BRANCH_PROTECTION_TOKEN }}
+        run: |
+          gh api \
+            --method PUT \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.repository }}/branches/main/protection \
+            --input - <<'EOF'
+          {
+            "required_status_checks": {
+              "strict": true,
+              "contexts": ["Lint & Type Check", "Unit Tests", "Next.js Build"]
+            },
+            "enforce_admins": false,
+            "required_pull_request_reviews": {
+              "required_approving_review_count": 1,
+              "dismiss_stale_reviews": true,
+              "require_code_owner_reviews": false
+            },
+            "restrictions": null,
+            "allow_force_pushes": false,
+            "allow_deletions": false,
+            "block_creations": false,
+            "required_conversation_resolution": true
+          }
+          EOF
+          echo "Branch protection applied to main."

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -1,0 +1,42 @@
+# Branch Protection — `main`
+
+## Rules in effect
+
+| Rule | Setting |
+|---|---|
+| Direct pushes to `main` | **Blocked** — all changes via PR |
+| Required approving reviews | **1** |
+| Dismiss stale reviews on new push | **Yes** |
+| Required CI checks before merge | `Lint & Type Check`, `Unit Tests`, `Next.js Build` |
+| Branches must be up-to-date before merge | **Yes** |
+| Force push | **Disabled** |
+| Branch deletion | **Disabled** |
+| Conversation resolution required | **Yes** |
+
+## Applying the rules
+
+Branch protection is applied automatically via the `branch-protection.yml` workflow when it is merged to `main`. It can also be triggered manually from **Actions → Apply Branch Protection → Run workflow**.
+
+### Prerequisites
+
+A GitHub Personal Access Token (classic) with `repo` scope must be stored as the repository secret `BRANCH_PROTECTION_TOKEN`. The token owner must have **Admin** access to the repository.
+
+```
+Settings → Secrets and variables → Actions → New repository secret
+Name:  BRANCH_PROTECTION_TOKEN
+Value: <PAT with repo scope>
+```
+
+## Development workflow
+
+```
+main          ← protected, no direct push
+  └── feat/my-feature   ← branch off main
+        └── PR → 1 review + CI green → merge
+```
+
+1. Branch off `main`: `git checkout -b feat/<description>-<issue>`
+2. Push and open a PR targeting `main`
+3. CI must pass (lint, type-check, tests, build)
+4. At least 1 reviewer must approve
+5. Merge — squash or merge commit, no force push


### PR DESCRIPTION
                                                                                                                                
  Summary                                                                                                                                                 
                                                                                                                                                          
  Blocks direct pushes to main and enforces code review + CI requirements via the GitHub API.                                                             
                                                                                                                                                          
  Rules applied                                                                                                                                           
                                                                                                                                                          
  - Direct pushes blocked — all changes via PR                                                                                                            
  - 1 required approving review; stale reviews dismissed on new push                                                                                      
  - CI must pass before merge: Lint & Type Check, Unit Tests, Next.js Build                                                                               
  - Force push and branch deletion disabled                                                                                                               
  - Conversation resolution required                                                                                                                      
                                                                                                                                                          
  How it works                                                                                                                                            
                                                                                                                                                          
  branch-protection.yml applies the rules via the GitHub API when merged to main, and can be re-run manually from Actions.                                
                                                                                                                                                          
  Required secret: BRANCH_PROTECTION_TOKEN — a PAT with repo scope from an admin account.                                                                 
                                                                                                                                                          
  Closes #95                                                                                                                                             
                                                                                                                                                          
  