### PR TITLE
feat: add admin-only contract upgrade mechanism

### DIFF
--- a/contracts/ajo/UPGRADE.md
+++ b/contracts/ajo/UPGRADE.md
@@ -1,0 +1,63 @@
+# Contract Upgrade Guide
+
+The Ajo contract exposes an admin-only `upgrade(new_wasm_hash)` function that replaces the running WASM in-place using Soroban's `update_current_contract_wasm`. All storage (members, cycles, balances) is preserved across upgrades.
+
+## Prerequisites
+
+- Stellar CLI installed (`stellar --version`)
+- Admin keypair available
+- New contract code compiled to WASM
+
+## Steps
+
+### 1. Build the new WASM
+
+```bash
+npm run contract:build
+# Output: contracts/ajo/target/wasm32-unknown-unknown/release/ajo.wasm
+```
+
+### 2. Upload the WASM blob (does not deploy a new contract)
+
+```bash
+stellar contract upload \
+  --network testnet \
+  --source <ADMIN_SECRET_KEY> \
+  --wasm contracts/ajo/target/wasm32-unknown-unknown/release/ajo.wasm
+# Prints: <NEW_WASM_HASH>
+```
+
+### 3. Call `upgrade` on the existing contract
+
+```bash
+stellar contract invoke \
+  --network testnet \
+  --source <ADMIN_SECRET_KEY> \
+  --id <CONTRACT_ID> \
+  -- upgrade \
+  --new_wasm_hash <NEW_WASM_HASH>
+```
+
+The contract emits an `upgraded` event containing the new WASM hash. Verify it in Stellar Explorer or via:
+
+```bash
+stellar events --contract-id <CONTRACT_ID> --topic upgraded
+```
+
+### 4. Verify
+
+```bash
+stellar contract invoke \
+  --network testnet \
+  --source <ADMIN_SECRET_KEY> \
+  --id <CONTRACT_ID> \
+  -- get_state
+```
+
+Confirm the circle state is intact and the new logic is active.
+
+## Notes
+
+- Only the `admin` address set during `initialize` can call `upgrade`.
+- No data migration is needed unless the new version changes storage key layouts — in that case add a `migrate()` function before calling `upgrade`.
+- For mainnet upgrades, test on testnet first and have the admin multisig approve the transaction.

--- a/contracts/ajo/src/lib.rs
+++ b/contracts/ajo/src/lib.rs
@@ -12,7 +12,7 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, token, vec, Address, Env, Symbol, Vec,
+    contract, contractimpl, contracttype, token, vec, Address, BytesN, Env, Symbol, Vec,
 };
 
 // ─── Storage keys ─────────────────────────────────────────────────────────────
@@ -216,6 +216,25 @@ impl AjoContract {
     /// Read-only: get all members.
     pub fn get_members(env: Env) -> Vec<Address> {
         env.storage().instance().get(&DataKey::Members).unwrap_or(vec![&env])
+    }
+
+    /// Upgrade the contract WASM. Admin-only.
+    ///
+    /// * `new_wasm_hash` – hash of the new WASM blob already uploaded to the network
+    ///
+    /// Emits an `upgraded` event so off-chain indexers can track deployments.
+    pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+
+        env.deployer().update_current_contract_wasm(new_wasm_hash.clone());
+
+        env.events()
+            .publish((Symbol::new(&env, "upgraded"),), (new_wasm_hash,));
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #73

Adds an in-place WASM upgrade path to the Ajo Soroban contract so bugs can be fixed post-deployment without migrating circles to a new contract address.

## Changes

- **`contracts/ajo/src/lib.rs`**
  - Imported `BytesN` from `soroban_sdk`
  - Added `upgrade(new_wasm_hash: BytesN<32>)` function:
    - Requires admin auth (`admin.require_auth()`)
    - Calls `env.deployer().update_current_contract_wasm()` to swap WASM in-place (all storage preserved)
    - Emits `upgraded` event with the new WASM hash

- **`contracts/ajo/UPGRADE.md`** — Step-by-step migration guide covering build → upload → invoke → verify.

## Acceptance Criteria

- [x] Admin-only `upgrade(new_wasm_hash)` function added
- [x] Upgrade emits event
- [x] Migration guide documented