### PR TITLE
feat: configure production environment on Vercel

### DIFF
--- a/docs/vercel-setup.md
+++ b/docs/vercel-setup.md
@@ -1,0 +1,33 @@
+# Vercel Production Setup
+
+## Dashboard environment variables
+
+The following secrets **must** be added in the Vercel dashboard under  
+**Project → Settings → Environment Variables** (Production + Preview scopes).
+
+| Variable | Description |
+|---|---|
+| `NEXTAUTH_URL` | Production URL, e.g. `https://ajosave.app` |
+| `NEXTAUTH_SECRET` | Random 32-byte secret (`openssl rand -base64 32`) |
+| `DATABASE_URL` | PostgreSQL connection string |
+| `REDIS_URL` | Redis connection string |
+| `STELLAR_AJO_CONTRACT_ID` | Deployed Soroban contract ID |
+| `STELLAR_SERVER_SECRET_KEY` | Stellar keypair secret for server signing |
+| `PAYSTACK_SECRET_KEY` | Paystack secret key |
+| `NEXT_PUBLIC_PAYSTACK_PUBLIC_KEY` | Paystack public key |
+| `NEXT_PUBLIC_APP_URL` | Production URL (same as `NEXTAUTH_URL`) |
+| `TERMII_API_KEY` | Termii SMS API key |
+| `CRON_SECRET` | Secret checked by `/api/cron/cycle` to reject unauthorized calls |
+
+Non-secret values (network, asset code, etc.) are already set in `vercel.json`.
+
+## Deployment settings
+
+- **Production branch**: `main` (set in Vercel dashboard → Git → Production Branch)
+- **Preview deployments**: enabled for all PRs via `github.autoAlias: true` in `vercel.json`
+- **Cron job**: `POST /api/cron/cycle` runs every hour (`0 * * * *`)
+
+## Verifying the cron
+
+After deploying, confirm the cron appears under  
+**Project → Settings → Cron Jobs** in the Vercel dashboard.

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,32 @@
 {
+  "git": {
+    "deploymentEnabled": {
+      "main": true
+    }
+  },
+  "github": {
+    "enabled": true,
+    "autoAlias": true,
+    "silent": false
+  },
   "crons": [
     {
       "path": "/api/cron/cycle",
       "schedule": "0 * * * *"
     }
-  ]
+  ],
+  "env": {
+    "NEXT_PUBLIC_APP_NAME": "Ajosave",
+    "STELLAR_NETWORK": "mainnet",
+    "STELLAR_HORIZON_URL": "https://horizon.stellar.org",
+    "STELLAR_NETWORK_PASSPHRASE": "Public Global Stellar Network ; September 2015",
+    "USDC_ASSET_CODE": "USDC",
+    "USDC_ISSUER": "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+    "TERMII_SENDER_ID": "Ajosave"
+  },
+  "build": {
+    "env": {
+      "STELLAR_NETWORK": "mainnet"
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Closes #91

Fully configures `vercel.json` for production and documents the required Vercel dashboard setup.

## Changes

- **`vercel.json`**
  - `git.deploymentEnabled.main: true` — production branch set to `main`
  - `github.enabled + autoAlias: true` — preview deployments enabled for all PRs
  - Cron job retained: `POST /api/cron/cycle` every hour
  - Non-secret env vars inlined (network, Stellar passphrase, USDC asset, Termii sender ID)

- **`docs/vercel-setup.md`** — Documents all secrets that must be added in the Vercel dashboard (NEXTAUTH_SECRET, DATABASE_URL, REDIS_URL, Stellar keys, Paystack keys, CRON_SECRET, etc.)

## Acceptance Criteria

- [x] All required env vars documented (set in Vercel dashboard per guide)
- [x] Preview deployments enabled for PRs
- [x] Production branch set to main
- [x] Cron job configured in vercel.json