### PR TITLE
feat: enforce HTTPS and set HSTS header

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,6 +4,31 @@ const nextConfig = {
   experimental: {
     serverComponentsExternalPackages: ["@stellar/stellar-sdk"],
   },
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=63072000; includeSubDomains; preload",
+          },
+        ],
+      },
+    ];
+  },
+  async redirects() {
+    return process.env.NODE_ENV === "production"
+      ? [
+          {
+            source: "/(.*)",
+            has: [{ type: "header", key: "x-forwarded-proto", value: "http" }],
+            destination: "https://www.ajosave.app/:path*",
+            permanent: true,
+          },
+        ]
+      : [];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

Adds HTTPS enforcement and HSTS security header to the Next.js app.

## Changes

- `next.config.mjs`: Added `headers()` to set `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload` on all routes
- `next.config.mjs`: Added `redirects()` to permanently redirect HTTP → HTTPS in production (via `x-forwarded-proto` header check)

## Acceptance Criteria

- [x] `Strict-Transport-Security` header set
- [x] `next.config.mjs` headers config updated
- [x] HTTP redirects to HTTPS

Closes #81