### PR TITLE
feat: add error.tsx boundaries for all major routes

### DIFF
--- a/src/app/auth/login/error.tsx
+++ b/src/app/auth/login/error.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect } from "react";
+import { Button } from "@/components/ui/Button";
+import styles from "../../error.module.css";
+
+export default function LoginError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.inner}>
+        <h2 className={styles.title}>Failed to load login</h2>
+        <p className={styles.message}>
+          Something went wrong. Please try again.
+        </p>
+        <Button onClick={reset}>Try again</Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/circles/create/error.tsx
+++ b/src/app/circles/create/error.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect } from "react";
+import { Button } from "@/components/ui/Button";
+import styles from "../../error.module.css";
+
+export default function CreateCircleError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.inner}>
+        <h2 className={styles.title}>Failed to load page</h2>
+        <p className={styles.message}>
+          Something went wrong while loading the create circle form.
+        </p>
+        <Button onClick={reset}>Try again</Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/circles/error.tsx
+++ b/src/app/circles/error.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect } from "react";
+import { Button } from "@/components/ui/Button";
+import styles from "../error.module.css";
+
+export default function CirclesError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.inner}>
+        <h2 className={styles.title}>Failed to load circles</h2>
+        <p className={styles.message}>
+          We couldn&apos;t fetch the circles. Please try again.
+        </p>
+        <Button onClick={reset}>Try again</Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/error.tsx
+++ b/src/app/dashboard/error.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect } from "react";
+import { Button } from "@/components/ui/Button";
+import styles from "../error.module.css";
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.inner}>
+        <h2 className={styles.title}>Failed to load dashboard</h2>
+        <p className={styles.message}>
+          We couldn&apos;t load your circles. Please try again.
+        </p>
+        <Button onClick={reset}>Try again</Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/error.module.css
+++ b/src/app/error.module.css
@@ -1,0 +1,27 @@
+.container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  padding: var(--space-12) var(--space-6);
+}
+
+.inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-4);
+  text-align: center;
+  max-width: 400px;
+}
+
+.title {
+  font-size: var(--text-2xl);
+  font-weight: var(--font-bold);
+  color: var(--color-text-primary);
+}
+
+.message {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect } from "react";
+import { Button } from "@/components/ui/Button";
+import styles from "./error.module.css";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.inner}>
+        <h2 className={styles.title}>Something went wrong</h2>
+        <p className={styles.message}>
+          An unexpected error occurred. Please try again.
+        </p>
+        <Button onClick={reset}>Try again</Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds Next.js `error.tsx` boundaries to all major route segments so unhandled server component errors show a user-friendly page instead of crashing the whole app.

## Changes

| File | Route |
|------|-------|
| `src/app/error.tsx` | Root-level fallback |
| `src/app/circles/error.tsx` | /circles |
| `src/app/circles/create/error.tsx` | /circles/create |
| `src/app/dashboard/error.tsx` | /dashboard |
| `src/app/auth/login/error.tsx` | /auth/login |
| `src/app/error.module.css` | Shared error page styles |

Each boundary:
- Shows a user-friendly error message specific to the route
- Renders a **Try again** button that calls `reset()`
- Logs the error to the console via `useEffect`

## Acceptance Criteria

- [x] `error.tsx` added to all major route segments
- [x] Shows user-friendly error message
- [x] "Try again" button calls `reset()`

Closes #64