### PR TITLE
feat(monitoring): set up Sentry APM — error tracking + performance traces

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,10 @@ REDIS_URL=redis://localhost:6379
 
 # ─── Cron ──────────────────────────────────────────────────────────────────────
 CRON_SECRET=replace_with_cron_secret
+
+# ─── Sentry (APM) ──────────────────────────────────────────────────────────────
+NEXT_PUBLIC_SENTRY_DSN=https://replace@oXXXXXX.ingest.sentry.io/XXXXXXX
+SENTRY_DSN=https://replace@oXXXXXX.ingest.sentry.io/XXXXXXX
+SENTRY_ORG=ajosave
+SENTRY_PROJECT=ajosave-nextjs
+SENTRY_AUTH_TOKEN=replace_with_sentry_auth_token

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,10 @@ jobs:
       TERMII_API_KEY: placeholder
       REDIS_URL: redis://localhost:6379
       CRON_SECRET: placeholder
+      NEXT_PUBLIC_SENTRY_DSN: ""
+      SENTRY_DSN: ""
+      SENTRY_ORG: ajosave
+      SENTRY_PROJECT: ajosave-nextjs
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,8 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    await import("./sentry.server.config");
+  }
+  if (process.env.NEXT_RUNTIME === "edge") {
+    await import("./sentry.edge.config");
+  }
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,9 +1,19 @@
+import { withSentryConfig } from "@sentry/nextjs";
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
   experimental: {
     serverComponentsExternalPackages: ["@stellar/stellar-sdk"],
+    instrumentationHook: true,
   },
 };
 
-export default nextConfig;
+export default withSentryConfig(nextConfig, {
+  org: process.env.SENTRY_ORG,
+  project: process.env.SENTRY_PROJECT,
+  silent: true,
+  widenClientFileUpload: true,
+  hideSourceMaps: true,
+  disableLogger: true,
+});

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
+    "@sentry/nextjs": "^8.28.0",
     "@stellar/stellar-sdk": "^12.3.0",
     "@tanstack/react-query": "^5.40.0",
     "axios": "^1.7.2",

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,0 +1,10 @@
+import * as Sentry from "@sentry/nextjs";
+
+Sentry.init({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  environment: process.env.NODE_ENV,
+  tracesSampleRate: process.env.NODE_ENV === "production" ? 0.2 : 1.0,
+  replaysOnErrorSampleRate: 1.0,
+  replaysSessionSampleRate: 0.05,
+  integrations: [Sentry.replayIntegration()],
+});

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -1,0 +1,7 @@
+import * as Sentry from "@sentry/nextjs";
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN ?? process.env.NEXT_PUBLIC_SENTRY_DSN,
+  environment: process.env.NODE_ENV,
+  tracesSampleRate: process.env.NODE_ENV === "production" ? 0.2 : 1.0,
+});

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,0 +1,7 @@
+import * as Sentry from "@sentry/nextjs";
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN ?? process.env.NEXT_PUBLIC_SENTRY_DSN,
+  environment: process.env.NODE_ENV,
+  tracesSampleRate: process.env.NODE_ENV === "production" ? 0.2 : 1.0,
+});

--- a/src/server/middleware/index.ts
+++ b/src/server/middleware/index.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
+import * as Sentry from "@sentry/nextjs";
 import type { ApiError } from "@/types";
 
 type Handler = (_req: NextRequest, _ctx?: unknown) => Promise<NextResponse>;
@@ -23,6 +24,7 @@ export function withErrorHandler(handler: Handler): Handler {
     try {
       return await handler(req, ctx);
     } catch (err) {
+      Sentry.captureException(err, { extra: { url: req.url, method: req.method } });
       console.error("[API Error]", err);
       return NextResponse.json<ApiError>(
         { success: false, error: "Internal server error", code: "INTERNAL_ERROR" },


### PR DESCRIPTION
## Summary

Resolves #92 — Sentry integrated for error tracking, performance tracing, and session replay across client, server, and edge runtimes.

## Changes

### Sentry config files
- `sentry.client.config.ts` — browser errors + session replay (5% sessions, 100% on error)
- `sentry.server.config.ts` — server-side error tracking + traces
- `sentry.edge.config.ts` — edge runtime error tracking

### `instrumentation.ts`
- Next.js 14 instrumentation hook that initialises Sentry on server/edge startup

### `next.config.mjs`
- Wrapped with `withSentryConfig` for source map uploads, tree-shaking, and hidden source maps in production

### `src/server/middleware/index.ts`
- `withErrorHandler` now calls `Sentry.captureException(err)` with request URL + method context before returning 500

### `package.json`
- Added `@sentry/nextjs@8.28.0`

### `.env.example`
- Documents `NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_DSN`, `SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_AUTH_TOKEN`

## Required Secrets (add to GitHub + Vercel)
| Variable | Where |
|----------|-------|
| `NEXT_PUBLIC_SENTRY_DSN` | GitHub secrets + Vercel env |
| `SENTRY_DSN` | GitHub secrets + Vercel env |
| `SENTRY_AUTH_TOKEN` | GitHub secrets (for source map upload) |
| `SENTRY_ORG` | GitHub vars |
| `SENTRY_PROJECT` | GitHub vars |

## Acceptance Criteria
- [x] Sentry integrated for error tracking
- [x] Performance traces for API routes (tracesSampleRate: 0.2 in prod)
- [x] Session replay configured (alerts on error rate spikes via Sentry Alerts UI)

> Configure alert rules in Sentry dashboard: Project Settings → Alerts → create an issue alert for error rate > threshold.

Closes #92