### PR TITLE
feat: serialize payouts to prevent sequence number conflicts

### DIFF
--- a/src/server/services/payout-lock.ts
+++ b/src/server/services/payout-lock.ts
@@ -1,0 +1,29 @@
+/**
+ * In-process mutex for serializing Stellar payout operations.
+ *
+ * Prevents concurrent payouts from racing on the same account sequence number.
+ * In a multi-instance deployment, replace with a distributed lock (e.g. Redis SET NX).
+ */
+
+const locks = new Set<string>();
+
+export class PayoutLockError extends Error {
+  constructor(circleId: string) {
+    super(`Payout already in progress for circle ${circleId}`);
+    this.name = "PayoutLockError";
+  }
+}
+
+/**
+ * Acquire a lock for the given key, run fn, then release.
+ * Throws PayoutLockError immediately if the lock is already held.
+ */
+export async function withPayoutLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  if (locks.has(key)) throw new PayoutLockError(key);
+  locks.add(key);
+  try {
+    return await fn();
+  } finally {
+    locks.delete(key);
+  }
+}

--- a/src/server/services/payout.service.ts
+++ b/src/server/services/payout.service.ts
@@ -1,23 +1,27 @@
 import { sendUsdcPayment } from "@/lib/stellar";
 import { getCircleById, getMembersByCircle, updateCircleStatus } from "./circle.service";
+import { withPayoutLock, PayoutLockError } from "./payout-lock";
 import type { Payout } from "@/types";
 import { randomUUID } from "crypto";
+
+export { PayoutLockError };
 
 // In-memory payout log — replace with DB
 const payouts: Payout[] = [];
 
 /**
  * Process a payout cycle for a circle:
- * 1. Find the next member in rotation who hasn't received payout
- * 2. Send the full pot (contributionUsdc × members) to their Stellar key
+ * 1. Acquire a per-circle lock to prevent concurrent sequence number conflicts
+ * 2. Send the full pot (contributionUsdc × members) to the recipient's Stellar key
  * 3. Record the payout and advance the cycle
  *
- * In production: recipient's Stellar key comes from the user record in DB.
+ * Throws PayoutLockError immediately if a payout is already in progress for this circle.
  */
 export async function processCyclePayout(
   circleId: string,
   recipientStellarKey: string
 ): Promise<Payout> {
+  return withPayoutLock(circleId, async () => {
   const circle = await getCircleById(circleId);
   if (!circle) throw new Error("Circle not found");
   if (circle.status !== "active") throw new Error("Circle is not active");
@@ -27,6 +31,7 @@ export async function processCyclePayout(
     parseFloat(circle.contributionUsdc) * circleMembers.length
   ).toFixed(7);
 
+  // sendUsdcPayment fetches a fresh account sequence number each call
   const txHash = await sendUsdcPayment(recipientStellarKey, totalPot);
 
   const payout: Payout = {
@@ -47,6 +52,7 @@ export async function processCyclePayout(
   }
 
   return payout;
+  }); // end withPayoutLock
 }
 
 export async function getPayoutsByCircle(circleId: string): Promise<Payout[]> {


### PR DESCRIPTION
## Summary
Prevents concurrent payout operations from racing on the same Stellar account sequence number.

## Type of change
- [x] Bug fix

## Related issues
Closes #40

## Changes
- **`src/server/services/payout-lock.ts`** — in-process mutex (`withPayoutLock`). Throws `PayoutLockError` immediately if a lock is already held for the same circle. Replace with Redis `SET NX` for multi-instance deployments.
- **`src/server/services/payout.service.ts`** — wraps `processCyclePayout` in the lock. `sendUsdcPayment` already calls `server.loadAccount()` on every invocation, so the sequence number is always fetched fresh.

## Behaviour
- Concurrent payout for the same circle → second caller gets `PayoutLockError: Payout already in progress for circle <id>`
- Sequential payouts work normally

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Types pass (`npm run type-check`)
- [x] No secrets committed