### PR TITLE
feat: integrate Soroban contract payout into backend service

### DIFF
--- a/src/lib/soroban.ts
+++ b/src/lib/soroban.ts
@@ -1,0 +1,33 @@
+import { contract, Keypair, Networks } from "@stellar/stellar-sdk";
+import { serverConfig } from "@/server/config";
+
+const networkPassphrase =
+  serverConfig.stellar.network === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
+
+/**
+ * Invoke AjoContract.payout() via Soroban RPC.
+ * The contract handles the token transfer; the backend only triggers it.
+ *
+ * @param contractId - The deployed Ajo contract address for this circle
+ * @returns The Soroban transaction hash
+ */
+export async function invokeContractPayout(contractId: string): Promise<string> {
+  const keypair = Keypair.fromSecret(serverConfig.stellar.serverSecretKey);
+  const signer = contract.basicNodeSigner(keypair, networkPassphrase);
+
+  const client = await contract.Client.from({
+    contractId,
+    networkPassphrase,
+    rpcUrl: serverConfig.stellar.sorobanRpcUrl,
+    publicKey: keypair.publicKey(),
+    ...signer,
+  });
+
+  // payout() takes no args — admin auth is checked inside the contract
+  // @ts-expect-error — method generated from contract ABI at runtime
+  const assembled = await client.payout();
+  const sent = await assembled.send();
+  // SentTransaction exposes the hash via the underlying getTransaction response
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (sent as any).hash ?? (sent as any).sendTransactionResponse?.hash ?? "";
+}

--- a/src/server/config/index.ts
+++ b/src/server/config/index.ts
@@ -10,6 +10,9 @@ export const serverConfig = {
       process.env.STELLAR_NETWORK_PASSPHRASE ?? "Test SDF Network ; September 2015",
     ajoContractId: process.env.STELLAR_AJO_CONTRACT_ID ?? "",
     serverSecretKey: process.env.STELLAR_SERVER_SECRET_KEY ?? "",
+    sorobanRpcUrl:
+      process.env.STELLAR_SOROBAN_RPC_URL ??
+      "https://soroban-testnet.stellar.org",
   },
   usdc: {
     issuer: process.env.USDC_ISSUER ?? "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",

--- a/src/server/services/payout.service.ts
+++ b/src/server/services/payout.service.ts
@@ -1,4 +1,5 @@
 import { sendUsdcPayment } from "@/lib/stellar";
+import { invokeContractPayout } from "@/lib/soroban";
 import { getCircleById, getMembersByCircle, updateCircleStatus } from "./circle.service";
 import type { Payout } from "@/types";
 import { randomUUID } from "crypto";
@@ -7,12 +8,12 @@ import { randomUUID } from "crypto";
 const payouts: Payout[] = [];
 
 /**
- * Process a payout cycle for a circle:
- * 1. Find the next member in rotation who hasn't received payout
- * 2. Send the full pot (contributionUsdc × members) to their Stellar key
- * 3. Record the payout and advance the cycle
+ * Process a payout cycle for a circle.
  *
- * In production: recipient's Stellar key comes from the user record in DB.
+ * If the circle has a contractId, the Soroban contract is the source of truth:
+ * it handles the token transfer and rotation internally.
+ *
+ * Falls back to direct Horizon payment for circles without a deployed contract.
  */
 export async function processCyclePayout(
   circleId: string,
@@ -27,7 +28,14 @@ export async function processCyclePayout(
     parseFloat(circle.contributionUsdc) * circleMembers.length
   ).toFixed(7);
 
-  const txHash = await sendUsdcPayment(recipientStellarKey, totalPot);
+  let txHash: string;
+  if (circle.contractId) {
+    // Soroban path: contract handles transfer, backend only triggers payout()
+    txHash = await invokeContractPayout(circle.contractId);
+  } else {
+    // Horizon fallback for circles without a deployed contract
+    txHash = await sendUsdcPayment(recipientStellarKey, totalPot);
+  }
 
   const payout: Payout = {
     id: randomUUID(),
@@ -41,7 +49,6 @@ export async function processCyclePayout(
 
   payouts.push(payout);
 
-  // Mark complete if all members have been paid
   if (circle.currentCycle >= circleMembers.length) {
     await updateCircleStatus(circleId, "completed");
   }


### PR DESCRIPTION
## Summary
Routes payout execution through the deployed Ajo Soroban contract instead of calling Horizon directly. The contract is now the source of truth for token transfers and cycle rotation.

## Type of change
- [x] New feature

## Related issues
Closes #79

## Changes
- **`src/lib/soroban.ts`** — `invokeContractPayout(contractId)` builds a `contract.Client` from the circle's contract address and calls `payout()` via Soroban RPC using `basicNodeSigner`. The contract handles the token transfer internally.
- **`src/server/services/payout.service.ts`** — `processCyclePayout` now branches on `circle.contractId`: Soroban path when present, Horizon fallback for circles without a deployed contract.
- **`src/server/config/index.ts`** — adds `sorobanRpcUrl` (env: `STELLAR_SOROBAN_RPC_URL`, defaults to testnet RPC).

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Types pass (`npm run type-check`)
- [x] No secrets committed