### PR TITLE
feat: add global toast notification system

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from "next/font/google";
 import "@/styles/globals.css";
 import "@/styles/components.css";
 import { Navbar } from "@/components/layout/Navbar";
+import { ToastProvider } from "@/components/ui/Toast";
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
 
@@ -24,8 +25,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" className={inter.variable}>
       <body>
-        <Navbar />
-        <main>{children}</main>
+        <ToastProvider>
+          <Navbar />
+          <main>{children}</main>
+        </ToastProvider>
       </body>
     </html>
   );

--- a/src/components/circle/ContributeButton.tsx
+++ b/src/components/circle/ContributeButton.tsx
@@ -2,35 +2,29 @@
 
 import { useState } from "react";
 import { Button } from "@/components/ui/Button";
+import { useToast } from "@/components/ui/Toast";
 
 export function ContributeButton({ circleId }: { circleId: string }) {
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const { toast } = useToast();
 
   const handleContribute = async () => {
     setLoading(true);
-    setError(null);
     try {
       const res = await fetch(`/api/circles/${circleId}/contribute`, { method: "POST" });
       const json = await res.json();
       if (!json.success) throw new Error(json.error);
+      toast("Redirecting to payment…", "info");
       window.location.href = json.data.authorizationUrl;
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to initiate payment");
+      toast(err instanceof Error ? err.message : "Failed to initiate payment", "error");
       setLoading(false);
     }
   };
 
   return (
-    <div>
-      <Button variant="accent" onClick={handleContribute} loading={loading}>
-        Contribute Now
-      </Button>
-      {error && (
-        <p style={{ marginTop: "0.5rem", fontSize: "var(--text-xs)", color: "var(--color-error)" }}>
-          {error}
-        </p>
-      )}
-    </div>
+    <Button variant="accent" onClick={handleContribute} loading={loading}>
+      Contribute Now
+    </Button>
   );
 }

--- a/src/components/ui/Toast.module.css
+++ b/src/components/ui/Toast.module.css
@@ -1,0 +1,66 @@
+.region {
+  position: fixed;
+  bottom: var(--space-6);
+  right: var(--space-6);
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  max-width: 360px;
+  width: calc(100vw - var(--space-12));
+  pointer-events: none;
+}
+
+.toast {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  background-color: var(--color-bg-elevated);
+  box-shadow: var(--shadow-md);
+  pointer-events: all;
+  animation: slide-in var(--transition-base) ease;
+}
+
+@keyframes slide-in {
+  from { opacity: 0; transform: translateX(100%); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+.icon {
+  font-size: var(--text-base);
+  line-height: 1;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.message {
+  flex: 1;
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  line-height: var(--leading-normal);
+}
+
+.close {
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  font-size: var(--text-lg);
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+}
+.close:hover { color: var(--color-text-primary); }
+
+/* Variants */
+.success { border-color: rgba(34, 197, 94, 0.3); }
+.success .icon { color: var(--color-success); }
+
+.error { border-color: rgba(239, 68, 68, 0.3); }
+.error .icon { color: var(--color-error); }
+
+.info { border-color: rgba(59, 130, 246, 0.3); }
+.info .icon { color: var(--color-info); }

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import styles from "./Toast.module.css";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type ToastVariant = "success" | "error" | "info";
+
+interface Toast {
+  id: string;
+  message: string;
+  variant: ToastVariant;
+}
+
+interface ToastContextValue {
+  toast: (message: string, variant?: ToastVariant) => void;
+}
+
+// ─── Context ──────────────────────────────────────────────────────────────────
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error("useToast must be used inside <ToastProvider>");
+  return ctx;
+}
+
+// ─── Provider ─────────────────────────────────────────────────────────────────
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const timers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  const dismiss = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+    const timer = timers.current.get(id);
+    if (timer) { clearTimeout(timer); timers.current.delete(id); }
+  }, []);
+
+  const toast = useCallback(
+    (message: string, variant: ToastVariant = "info") => {
+      const id = `${Date.now()}-${Math.random()}`;
+      setToasts((prev) => [...prev, { id, message, variant }]);
+      const timer = setTimeout(() => dismiss(id), 5000);
+      timers.current.set(id, timer);
+    },
+    [dismiss],
+  );
+
+  // Clean up all timers on unmount
+  useEffect(() => {
+    const t = timers.current;
+    return () => { t.forEach(clearTimeout); };
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ toast }}>
+      {children}
+      <div
+        role="region"
+        aria-label="Notifications"
+        aria-live="polite"
+        aria-atomic="false"
+        className={styles.region}
+      >
+        {toasts.map((t) => (
+          <ToastItem key={t.id} toast={t} onDismiss={dismiss} />
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+// ─── Item ─────────────────────────────────────────────────────────────────────
+
+const ICONS: Record<ToastVariant, string> = {
+  success: "✓",
+  error: "✕",
+  info: "ℹ",
+};
+
+function ToastItem({
+  toast,
+  onDismiss,
+}: {
+  toast: Toast;
+  onDismiss: (id: string) => void;
+}) {
+  return (
+    <div
+      role="alert"
+      className={`${styles.toast} ${styles[toast.variant]}`}
+      data-testid="toast"
+    >
+      <span className={styles.icon} aria-hidden="true">
+        {ICONS[toast.variant]}
+      </span>
+      <span className={styles.message}>{toast.message}</span>
+      <button
+        type="button"
+        className={styles.close}
+        onClick={() => onDismiss(toast.id)}
+        aria-label="Dismiss notification"
+      >
+        ×
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
- ToastProvider with success/error/info variants
- Auto-dismiss after 5s, accessible via aria-live region
- useToast hook for use in any client component
- ContributeButton updated to use toast instead of inline error

Closes #56

## Summary

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs
- [ ] Smart contract change


## Checklist
- [ ] Tests pass (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Types pass (`npm run type-check`)
- [ ] Contract tests pass (`npm run contract:test`) if applicable
- [ ] No secrets committed
