### PR TITLE
feat: add E2E tests with Playwright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,51 @@ jobs:
       - name: Run migrations down
         run: npm run migrate:down
 
+  e2e:
+    name: E2E Tests (Playwright)
+    runs-on: ubuntu-latest
+    needs: [build]
+    env:
+      NEXT_PUBLIC_APP_URL: http://localhost:3000
+      NEXT_PUBLIC_APP_NAME: Ajosave
+      NEXTAUTH_URL: http://localhost:3000
+      NEXTAUTH_SECRET: ci-secret-placeholder
+      DATABASE_URL: postgresql://user:password@localhost:5432/ajosave
+      STELLAR_NETWORK: testnet
+      STELLAR_HORIZON_URL: https://horizon-testnet.stellar.org
+      STELLAR_NETWORK_PASSPHRASE: "Test SDF Network ; September 2015"
+      STELLAR_SERVER_SECRET_KEY: SXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+      USDC_ISSUER: GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
+      USDC_ASSET_CODE: USDC
+      PAYSTACK_SECRET_KEY: sk_test_placeholder
+      TERMII_API_KEY: placeholder
+      REDIS_URL: redis://localhost:6379
+      CRON_SECRET: placeholder
+      NEXT_PUBLIC_SENTRY_DSN: ""
+      SENTRY_DSN: ""
+      SENTRY_ORG: ajosave
+      SENTRY_PROJECT: ajosave-nextjs
+      PLAYWRIGHT_BASE_URL: http://localhost:3000
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20, cache: npm }
+      - run: npm ci
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+      - name: Build Next.js
+        run: npm run build
+      - name: Run E2E tests
+        run: npx playwright test --reporter=github
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ vars.STAGING_URL || 'http://localhost:3000' }}
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
   contract-test:
     name: Soroban Contract Tests
     runs-on: ubuntu-latest
@@ -103,9 +148,12 @@ jobs:
         with: { targets: wasm32-unknown-unknown }
       - uses: Swatinem/rust-cache@v2
         with: { workspaces: contracts }
-      - name: Run contract tests
+      - name: Run contract unit tests
         working-directory: contracts
-        run: cargo test
+        run: cargo test --lib
+      - name: Run Soroban integration tests
+        working-directory: contracts
+        run: cargo test integration_tests
 
   deploy-contract-testnet:
     name: Deploy Contract to Testnet

--- a/e2e/contribute.spec.ts
+++ b/e2e/contribute.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from "@playwright/test";
+
+const AUTH_COOKIE = {
+  name: "next-auth.session-token",
+  value: "e2e-test-session",
+  domain: "localhost",
+  path: "/",
+  httpOnly: true,
+  sameSite: "Lax" as const,
+};
+
+const CIRCLE_ID = "circle-active";
+
+test.describe("Contribute", () => {
+  test.beforeEach(async ({ page, context }) => {
+    await context.addCookies([AUTH_COOKIE]);
+
+    await page.route("/api/auth/session", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          user: { id: "user-3", name: "Member User", phone: "+2348011111111" },
+          expires: "2099-01-01",
+        }),
+      })
+    );
+  });
+
+  test("contribute button visible for active circle member", async ({ page }) => {
+    await page.goto(`/circles/${CIRCLE_ID}`);
+    await expect(page.getByRole("button", { name: /contribute now/i })).toBeVisible();
+  });
+
+  test("contribute redirects to Paystack on success", async ({ page }) => {
+    const paystackUrl = "https://checkout.paystack.com/test-ref";
+
+    await page.route(`/api/circles/${CIRCLE_ID}/contribute`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: { authorizationUrl: paystackUrl },
+        }),
+      })
+    );
+
+    // Intercept the navigation to Paystack so the test doesn't actually leave
+    let navigatedTo = "";
+    page.on("framenavigated", (frame) => {
+      if (frame === page.mainFrame()) navigatedTo = frame.url();
+    });
+
+    await page.goto(`/circles/${CIRCLE_ID}`);
+    await page.getByRole("button", { name: /contribute now/i }).click();
+
+    // Wait briefly for the redirect to be triggered
+    await page.waitForTimeout(500);
+    expect(navigatedTo).toContain("paystack");
+  });
+
+  test("shows error toast when contribute API fails", async ({ page }) => {
+    await page.route(`/api/circles/${CIRCLE_ID}/contribute`, (route) =>
+      route.fulfill({
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({ success: false, error: "Already contributed this cycle" }),
+      })
+    );
+
+    await page.goto(`/circles/${CIRCLE_ID}`);
+    await page.getByRole("button", { name: /contribute now/i }).click();
+
+    await expect(page.getByText(/already contributed/i)).toBeVisible();
+  });
+});

--- a/e2e/create-circle.spec.ts
+++ b/e2e/create-circle.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from "@playwright/test";
+
+// Simulate an authenticated session cookie so protected pages load
+const AUTH_COOKIE = {
+  name: "next-auth.session-token",
+  value: "e2e-test-session",
+  domain: "localhost",
+  path: "/",
+  httpOnly: true,
+  sameSite: "Lax" as const,
+};
+
+test.describe("Create Circle", () => {
+  test.beforeEach(async ({ page, context }) => {
+    // Mock the session endpoint so the app treats us as logged in
+    await context.addCookies([AUTH_COOKIE]);
+    await page.route("/api/auth/session", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          user: { id: "user-1", name: "Test User", phone: "+2348012345678" },
+          expires: "2099-01-01",
+        }),
+      })
+    );
+  });
+
+  test("create circle form renders required fields", async ({ page }) => {
+    await page.goto("/circles/create");
+    await expect(page.getByLabel(/circle name/i)).toBeVisible();
+    await expect(page.getByLabel(/contribution/i)).toBeVisible();
+    await expect(page.getByLabel(/max members/i)).toBeVisible();
+    await expect(page.getByRole("button", { name: /create circle/i })).toBeVisible();
+  });
+
+  test("submits form and redirects on success", async ({ page }) => {
+    await page.route("/api/circles", (route) =>
+      route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, data: { id: "circle-abc" } }),
+      })
+    );
+
+    await page.goto("/circles/create");
+    await page.getByLabel(/circle name/i).fill("Test Ajo Circle");
+    await page.getByLabel(/contribution/i).fill("5000");
+    await page.getByLabel(/max members/i).fill("5");
+    await page.getByRole("button", { name: /create circle/i }).click();
+
+    await expect(page).toHaveURL(/\/circles\/circle-abc/);
+  });
+
+  test("shows validation error for missing fields", async ({ page }) => {
+    await page.goto("/circles/create");
+    await page.getByRole("button", { name: /create circle/i }).click();
+    // HTML5 required validation or custom error message
+    const nameInput = page.getByLabel(/circle name/i);
+    await expect(nameInput).toBeFocused();
+  });
+
+  test("shows error toast when API fails", async ({ page }) => {
+    await page.route("/api/circles", (route) =>
+      route.fulfill({
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({ success: false, error: "Name already taken" }),
+      })
+    );
+
+    await page.goto("/circles/create");
+    await page.getByLabel(/circle name/i).fill("Duplicate Circle");
+    await page.getByLabel(/contribution/i).fill("5000");
+    await page.getByLabel(/max members/i).fill("5");
+    await page.getByRole("button", { name: /create circle/i }).click();
+
+    await expect(page.getByText(/name already taken/i)).toBeVisible();
+  });
+});

--- a/e2e/join-circle.spec.ts
+++ b/e2e/join-circle.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from "@playwright/test";
+
+const AUTH_COOKIE = {
+  name: "next-auth.session-token",
+  value: "e2e-test-session",
+  domain: "localhost",
+  path: "/",
+  httpOnly: true,
+  sameSite: "Lax" as const,
+};
+
+const CIRCLE_ID = "circle-xyz";
+
+test.describe("Join Circle", () => {
+  test.beforeEach(async ({ page, context }) => {
+    await context.addCookies([AUTH_COOKIE]);
+
+    await page.route("/api/auth/session", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          user: { id: "user-2", name: "Test User", phone: "+2348099999999" },
+          expires: "2099-01-01",
+        }),
+      })
+    );
+
+    // Mock circle detail page data
+    await page.route(`/api/circles/${CIRCLE_ID}`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: {
+            id: CIRCLE_ID,
+            name: "Open Ajo",
+            status: "open",
+            contributionNgn: 10000,
+            maxMembers: 5,
+            currentCycle: 0,
+            cycleFrequency: "monthly",
+            creatorId: "user-1",
+          },
+        }),
+      })
+    );
+  });
+
+  test("join button visible for open circle non-member", async ({ page }) => {
+    await page.goto(`/circles/${CIRCLE_ID}`);
+    await expect(page.getByRole("button", { name: /join circle/i })).toBeVisible();
+  });
+
+  test("join succeeds and shows confirmation", async ({ page }) => {
+    await page.route(`/api/circles/${CIRCLE_ID}/join`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true }),
+      })
+    );
+
+    await page.goto(`/circles/${CIRCLE_ID}`);
+    await page.getByRole("button", { name: /join circle/i }).click();
+
+    // Expect success feedback (toast or inline message)
+    await expect(page.getByText(/joined/i)).toBeVisible();
+  });
+
+  test("join shows error when circle is full", async ({ page }) => {
+    await page.route(`/api/circles/${CIRCLE_ID}/join`, (route) =>
+      route.fulfill({
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({ success: false, error: "Circle is full" }),
+      })
+    );
+
+    await page.goto(`/circles/${CIRCLE_ID}`);
+    await page.getByRole("button", { name: /join circle/i }).click();
+
+    await expect(page.getByText(/circle is full/i)).toBeVisible();
+  });
+});

--- a/e2e/login.spec.ts
+++ b/e2e/login.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("OTP Login", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/auth/login");
+  });
+
+  test("shows phone step by default", async ({ page }) => {
+    await expect(page.getByRole("heading", { name: /sign in/i })).toBeVisible();
+    await expect(page.getByLabel(/phone number/i)).toBeVisible();
+    await expect(page.getByRole("button", { name: /send code/i })).toBeVisible();
+  });
+
+  test("advances to OTP step after submitting phone", async ({ page }) => {
+    // Intercept the send-otp API so we don't need a real SMS service
+    await page.route("/api/auth/send-otp", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ success: true }) })
+    );
+
+    await page.getByLabel(/phone number/i).fill("8012345678");
+    await page.getByRole("button", { name: /send code/i }).click();
+
+    await expect(page.getByRole("heading", { name: /enter your otp/i })).toBeVisible();
+    await expect(page.getByLabel(/6-digit code/i)).toBeVisible();
+  });
+
+  test("shows error when send-otp fails", async ({ page }) => {
+    await page.route("/api/auth/send-otp", (route) =>
+      route.fulfill({
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({ success: false, error: "Invalid phone number" }),
+      })
+    );
+
+    await page.getByLabel(/phone number/i).fill("0000000000");
+    await page.getByRole("button", { name: /send code/i }).click();
+
+    await expect(page.getByRole("alert")).toContainText("Invalid phone number");
+  });
+
+  test("verify button disabled until 6 digits entered", async ({ page }) => {
+    await page.route("/api/auth/send-otp", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ success: true }) })
+    );
+
+    await page.getByLabel(/phone number/i).fill("8012345678");
+    await page.getByRole("button", { name: /send code/i }).click();
+
+    const verifyBtn = page.getByRole("button", { name: /verify/i });
+    await expect(verifyBtn).toBeDisabled();
+
+    await page.getByLabel(/6-digit code/i).fill("12345");
+    await expect(verifyBtn).toBeDisabled();
+
+    await page.getByLabel(/6-digit code/i).fill("123456");
+    await expect(verifyBtn).toBeEnabled();
+  });
+
+  test("shows error on invalid OTP", async ({ page }) => {
+    await page.route("/api/auth/send-otp", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ success: true }) })
+    );
+    await page.route("/api/auth/callback/credentials", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "CredentialsSignin" }),
+      })
+    );
+
+    await page.getByLabel(/phone number/i).fill("8012345678");
+    await page.getByRole("button", { name: /send code/i }).click();
+    await page.getByLabel(/6-digit code/i).fill("000000");
+    await page.getByRole("button", { name: /verify/i }).click();
+
+    await expect(page.getByRole("alert")).toContainText(/invalid or expired/i);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
+        "@playwright/test": "^1.44.1",
         "@testing-library/jest-dom": "^6.4.6",
         "@testing-library/react": "^16.0.0",
         "@types/node": "^20.14.9",
@@ -2161,6 +2162,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.44.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.1.tgz",
+      "integrity": "sha512-1hZ4TNvD5z9VuhNJ/walIjvMVvYkZKf71axoF/uiAqpntQJXpG64dlXhoDXE3OczPuTuvjf/M5KWFg5VAVUS3Q==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.44.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@prisma/instrumentation": {
@@ -10850,6 +10867,52 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.44.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.1.tgz",
+      "integrity": "sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.44.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.44.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.1.tgz",
+      "integrity": "sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
     "contract:build": "cd contracts && stellar contract build",
     "contract:test": "cd contracts && cargo test",
     "contract:deploy": "ts-node scripts/deploy-contract.ts",
@@ -58,6 +60,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@playwright/test": "^1.44.1",
     "@testing-library/jest-dom": "^6.4.6",
     "@testing-library/react": "^16.0.0",
     "@types/node": "^20.14.9",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  projects: [
+    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+  ],
+});


### PR DESCRIPTION
- Playwright installed and configured (playwright.config.ts)
- Tests for OTP login, create circle, join circle, contribute
- API routes mocked so tests run without live backend
- E2E CI job added to ci.yml (runs after build, uploads report on failure)
- test:e2e and test:e2e:ui scripts added to package.json

Closes #99

## Summary

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs
- [ ] Smart contract change


## Checklist
- [ ] Tests pass (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Types pass (`npm run type-check`)
- [ ] Contract tests pass (`npm run contract:test`) if applicable
- [ ] No secrets committed
