### PR TITLE
feat(#80): deploy Soroban contract per circle creation

### DIFF
--- a/src/lib/soroban.ts
+++ b/src/lib/soroban.ts
@@ -1,8 +1,55 @@
 import { contract, Keypair, Networks } from "@stellar/stellar-sdk";
 import { serverConfig } from "@/server/config";
+import { execSync } from "child_process";
+import * as path from "path";
+import * as fs from "fs";
 
 const networkPassphrase =
   serverConfig.stellar.network === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
+
+const rpcUrl = serverConfig.stellar.sorobanRpcUrl;
+const networkFlag =
+  serverConfig.stellar.network === "mainnet"
+    ? `--network-passphrase "Public Global Stellar Network ; September 2015"`
+    : `--network-passphrase "Test SDF Network ; September 2015"`;
+
+/**
+ * Deploy a new Ajo contract instance via the Stellar CLI.
+ * Returns the deployed contract ID.
+ *
+ * Estimated deploy cost: ~0.01 XLM in transaction fees on testnet.
+ * On mainnet, expect ~0.01–0.05 XLM depending on network congestion.
+ */
+export async function deployAjoContract(): Promise<string> {
+  const wasmPath = path.resolve(
+    process.cwd(),
+    "contracts/target/wasm32-unknown-unknown/release/ajosave_ajo.wasm"
+  );
+
+  if (!fs.existsSync(wasmPath)) {
+    throw new Error(
+      "Ajo contract WASM not found. Run `npm run contract:build` first."
+    );
+  }
+
+  const sourceKey = serverConfig.stellar.serverSecretKey;
+  if (!sourceKey) {
+    throw new Error("STELLAR_SERVER_SECRET_KEY is not set.");
+  }
+
+  const output = execSync(
+    `stellar contract deploy --wasm ${wasmPath} --source ${sourceKey} --rpc-url ${rpcUrl} ${networkFlag}`,
+    { encoding: "utf-8" }
+  );
+
+  const contractId = output.trim();
+  if (!contractId) {
+    throw new Error("Contract deployment returned empty contract ID.");
+  }
+
+  console.info(`[Soroban] Deployed new Ajo contract: ${contractId}`);
+  return contractId;
+}
 
 /**
  * Invoke AjoContract.payout() via Soroban RPC.

--- a/src/server/services/__tests__/circle.service.test.ts
+++ b/src/server/services/__tests__/circle.service.test.ts
@@ -1,0 +1,74 @@
+import { createCircle } from "@/server/services/circle.service";
+import * as db from "@/lib/db";
+import * as soroban from "@/lib/soroban";
+import * as fx from "@/lib/fx";
+
+jest.mock("@/lib/db");
+jest.mock("@/lib/soroban");
+jest.mock("@/lib/fx");
+
+const mockQuery = db.query as jest.MockedFunction<typeof db.query>;
+const mockDeployAjoContract = soroban.deployAjoContract as jest.MockedFunction<typeof soroban.deployAjoContract>;
+const mockGetNgnPerUsdc = fx.getNgnPerUsdc as jest.MockedFunction<typeof fx.getNgnPerUsdc>;
+
+const INPUT = {
+  name: "Test Circle",
+  contributionNgn: 16000,
+  maxMembers: 5,
+  cycleFrequency: "monthly" as const,
+  payoutMethod: "fixed" as const,
+};
+
+const CIRCLE_ROW = {
+  id: "circle-1",
+  name: "Test Circle",
+  creatorId: "user-1",
+  contributionUsdc: "10.0000000",
+  contributionNgn: 16000,
+  maxMembers: 5,
+  cycleFrequency: "monthly",
+  payoutMethod: "fixed",
+  contractId: "CDEPLOYEDCONTRACTID",
+  status: "open",
+  currentCycle: 0,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetNgnPerUsdc.mockResolvedValue(1600);
+});
+
+describe("createCircle", () => {
+  it("deploys a contract and stores contractId in the circle record", async () => {
+    mockDeployAjoContract.mockResolvedValue("CDEPLOYEDCONTRACTID");
+    mockQuery.mockResolvedValue({ rows: [CIRCLE_ROW], rowCount: 1 } as any);
+
+    const circle = await createCircle("user-1", INPUT);
+
+    expect(mockDeployAjoContract).toHaveBeenCalledTimes(1);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO circles"),
+      expect.arrayContaining(["CDEPLOYEDCONTRACTID"])
+    );
+    expect(circle.contractId).toBe("CDEPLOYEDCONTRACTID");
+  });
+
+  it("creates circle with null contractId when deployment fails", async () => {
+    mockDeployAjoContract.mockRejectedValue(new Error("WASM not found"));
+    mockQuery.mockResolvedValue({
+      rows: [{ ...CIRCLE_ROW, contractId: null }],
+      rowCount: 1,
+    } as any);
+
+    const circle = await createCircle("user-1", INPUT);
+
+    // Circle is still created even if deployment fails
+    expect(circle).toBeDefined();
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO circles"),
+      expect.arrayContaining([null])
+    );
+  });
+});

--- a/src/server/services/circle.service.ts
+++ b/src/server/services/circle.service.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "crypto";
 import type { Circle, Member, CircleStatus } from "@/types";
 import type { CreateCircleInput } from "@/types/schemas";
 import { getNgnPerUsdc } from "@/lib/fx";
+import { deployAjoContract } from "@/lib/soroban";
 
 export const ngnToUsdc = async (ngn: number): Promise<string> => {
   const rate = await getNgnPerUsdc();
@@ -15,14 +16,23 @@ export async function createCircle(
 ): Promise<Circle> {
   const id = randomUUID();
   const contributionUsdc = await ngnToUsdc(input.contributionNgn);
+
+  // Deploy a dedicated Soroban contract instance for this circle
+  let contractId: string | null = null;
+  try {
+    contractId = await deployAjoContract();
+  } catch (err) {
+    console.error("[createCircle] Contract deployment failed, proceeding without contractId:", err);
+  }
+
   const { rows } = await query<Circle>(
     `INSERT INTO circles
        (id, name, creator_id, contribution_usdc, contribution_ngn,
-        max_members, cycle_frequency, payout_method, status, current_cycle, created_at, updated_at)
-     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,'open',0,NOW(),NOW())
+        max_members, cycle_frequency, payout_method, contract_id, status, current_cycle, created_at, updated_at)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,'open',0,NOW(),NOW())
      RETURNING *`,
     [id, input.name, creatorId, contributionUsdc, input.contributionNgn,
-     input.maxMembers, input.cycleFrequency, input.payoutMethod]
+     input.maxMembers, input.cycleFrequency, input.payoutMethod, contractId]
   );
   return rows[0];
 }


### PR DESCRIPTION
Closes #80

## Changes

### `src/lib/soroban.ts` — `deployAjoContract()`
Deploys a new Ajo contract WASM instance via the Stellar CLI and returns the contract ID.

### `src/server/services/circle.service.ts` — `createCircle()`
- Calls `deployAjoContract()` before inserting the circle record
- Stores the returned `contractId` in `circles.contract_id` (column already exists in schema)
- Deployment failure is **non-fatal**: circle is created with `contractId = null` and falls back to the Horizon direct payment path at payout time

## Deploy cost estimate
| Network | Estimated cost |
|---------|---------------|
| Testnet | ~0.01 XLM |
| Mainnet | ~0.01–0.05 XLM (varies with congestion) |

## Tests
`src/server/services/__tests__/circle.service.test.ts`:
- Successful deployment → `contractId` stored in circle
- Deployment failure → circle created with `null` contractId (graceful degradation)