### PR TITLE
docs: add CHANGELOG.md following Keep a Changelog format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to Ajosave are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-04-24
+
+### Added
+
+- Soroban smart contract (`contracts/ajo/`) implementing the full Ajo circle lifecycle: `initialize`, `join`, `contribute`, `payout`, `upgrade`
+- On-chain events for all state transitions: `initialized`, `started`, `joined`, `contributed`, `payout`, `completed`, `defaulted`, `upgraded`
+- OTP phone authentication via Termii SMS and NextAuth session management
+- JWT session expiry and secure cookie handling
+- Circle creation, browse, and join flows (Next.js 14 App Router)
+- Dashboard for tracking a user's active circles and contribution history
+- Paystack NGN on-ramp for fiat contributions
+- PostgreSQL persistence for circle records and payout state
+- Redis-backed rate limiting and caching
+- Soroban payout integration — server-side signing and submission to Stellar network
+- Docker and docker-compose configuration for local development
+- Vercel deployment configuration (`vercel.json`)
+- CI pipeline (GitHub Actions): lint, type-check, Prettier format check, unit tests with Codecov, Next.js build, Soroban contract tests, and automatic testnet contract deployment on merge to `main`
+- Automated PostgreSQL backup workflow
+- Branch protection and PR validation checks via GitHub Actions
+- HTTPS/HSTS and Content Security Policy (CSP) response headers
+- SQL injection prevention via parameterised queries
+- Sentry APM integration for client, server, and edge runtimes
+- Health check endpoint (`/api/health`)
+- `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and `SECURITY.md`
+
+### Infrastructure
+
+- Stellar Testnet contract deployment: `CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC`
+
+[Unreleased]: https://github.com/JosephOnuh/ajosave/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/JosephOnuh/ajosave/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ STELLAR_AJO_CONTRACT_ID=CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC
 
 Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR.
 
+See [CHANGELOG.md](CHANGELOG.md) for a full history of changes.
+
 - Bugs → [Bug Report](.github/ISSUE_TEMPLATE/bug_report.md)
 - Features → [Feature Request](.github/ISSUE_TEMPLATE/feature_request.md)
 - Security → **security@ajosave.app**


### PR DESCRIPTION
Creates CHANGELOG.md at the repo root with an [Unreleased] section and a [0.1.0] entry documenting all features shipped in the initial release. Links the changelog from the Contributing section of README.md.

Closes #112

## Summary

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs
- [ ] Smart contract change

## Related issues
Closes #

## Checklist
- [ ] Tests pass (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Types pass (`npm run type-check`)
- [ ] Contract tests pass (`npm run contract:test`) if applicable
- [ ] No secrets committed
