### PR TITLE
feat: add copy button for IDs and hashes

### DIFF
--- a/src/components/admin/CirclesTable.tsx
+++ b/src/components/admin/CirclesTable.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import type { AdminCircleRow } from "@/server/services/admin.service";
 import { CircleStatusBadge } from "@/components/ui/CircleStatusBadge";
 import { Button } from "@/components/ui/Button";
+import { CopyableText } from "@/components/ui/CopyableText";
 import { format } from "date-fns";
 import styles from "../admin.module.css";
 
@@ -14,7 +15,7 @@ interface CirclesTableProps {
 export function CirclesTable({ circles }: CirclesTableProps) {
   const [payingOut, setPayingOut] = useState<string | null>(null);
   const [payoutError, setPayoutError] = useState<string | null>(null);
-  const [payoutSuccess, setPayoutSuccess] = useState<string | null>(null);
+  const [payoutSuccess, setPayoutSuccess] = useState<{ message: string; txHash: string } | null>(null);
 
   const handleManualPayout = async (circleId: string) => {
     setPayingOut(circleId);
@@ -27,7 +28,10 @@ export function CirclesTable({ circles }: CirclesTableProps) {
 
       if (!json.success) throw new Error(json.error);
 
-      setPayoutSuccess(`Payout triggered. TX: ${json.data.txHash.slice(0, 16)}…`);
+      setPayoutSuccess({
+        message: "Payout triggered successfully",
+        txHash: json.data.txHash,
+      });
       setTimeout(() => setPayoutSuccess(null), 5000);
     } catch (err) {
       setPayoutError(err instanceof Error ? err.message : "Payout failed");
@@ -45,7 +49,12 @@ export function CirclesTable({ circles }: CirclesTableProps) {
       {payoutError && <div className={styles.error}>{payoutError}</div>}
       {payoutSuccess && (
         <div style={{ background: "rgba(34, 197, 94, 0.1)", border: "1px solid var(--color-success)", borderRadius: "var(--radius-md)", padding: "var(--space-4) var(--space-6)", color: "var(--color-success)", marginBottom: "var(--space-6)" }}>
-          {payoutSuccess}
+          {payoutSuccess.message} — TX:{" "}
+          <CopyableText
+            text={payoutSuccess.txHash}
+            displayText={`${payoutSuccess.txHash.slice(0, 16)}…`}
+            label="Copy transaction hash"
+          />
         </div>
       )}
 

--- a/src/components/admin/PayoutsTable.tsx
+++ b/src/components/admin/PayoutsTable.tsx
@@ -2,6 +2,7 @@
 
 import type { AdminPayoutRow } from "@/server/services/admin.service";
 import { format } from "date-fns";
+import { CopyableText } from "@/components/ui/CopyableText";
 import styles from "../admin.module.css";
 
 interface PayoutsTableProps {
@@ -30,7 +31,13 @@ export function PayoutsTable({ payouts }: PayoutsTableProps) {
           {payouts.map((payout) => (
             <tr key={payout.id}>
               <td>{payout.circleName}</td>
-              <td className={styles.monospace}>{payout.recipientUserId.slice(0, 12)}…</td>
+              <td className={styles.monospace}>
+                <CopyableText
+                  text={payout.recipientUserId}
+                  displayText={`${payout.recipientUserId.slice(0, 12)}…`}
+                  label="Copy user ID"
+                />
+              </td>
               <td>#{payout.cycleNumber}</td>
               <td>{parseFloat(payout.amountUsdc).toFixed(2)}</td>
               <td>
@@ -41,7 +48,11 @@ export function PayoutsTable({ payouts }: PayoutsTableProps) {
                   className={styles.monospace}
                   style={{ color: "var(--color-brand-primary)", textDecoration: "underline" }}
                 >
-                  {payout.txHash.slice(0, 16)}…
+                  <CopyableText
+                    text={payout.txHash}
+                    displayText={`${payout.txHash.slice(0, 16)}…`}
+                    label="Copy transaction hash"
+                  />
                 </a>
               </td>
               <td>{format(new Date(payout.paidAt), "MMM d, yyyy HH:mm")}</td>

--- a/src/components/circle/MemberPayoutList.tsx
+++ b/src/components/circle/MemberPayoutList.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import type { Circle, Member } from "@/types";
 import { Button } from "@/components/ui/Button";
+import { CopyableText } from "@/components/ui/CopyableText";
 import styles from "./MemberPayoutList.module.css";
 
 interface Props {
@@ -67,7 +68,11 @@ export function MemberPayoutList({ circle, initialMembers, isCreator }: Props) {
                 </span>
 
                 <span className={styles.memberId}>
-                  Member {m.userId.slice(0, 8)}…
+                  <CopyableText
+                    text={m.userId}
+                    displayText={`Member ${m.userId.slice(0, 8)}…`}
+                    label="Copy member ID"
+                  />
                 </span>
 
                 <span className={styles.statusTag}>

--- a/src/components/ui/CopyButton.module.css
+++ b/src/components/ui/CopyButton.module.css
@@ -1,0 +1,27 @@
+.copyButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-secondary);
+  background: transparent;
+  transition: all var(--transition-fast);
+  cursor: pointer;
+  border: none;
+}
+
+.copyButton:hover {
+  color: var(--color-brand-primary);
+  background-color: var(--color-bg-elevated);
+}
+
+.copyButton:active {
+  transform: scale(0.95);
+}
+
+.icon {
+  display: block;
+  width: 16px;
+  height: 16px;
+}

--- a/src/components/ui/CopyButton.tsx
+++ b/src/components/ui/CopyButton.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState } from "react";
+import styles from "./CopyButton.module.css";
+
+interface CopyButtonProps {
+  text: string;
+  label?: string;
+}
+
+export function CopyButton({ text, label = "Copy" }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error("Failed to copy:", err);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      className={styles.copyButton}
+      onClick={handleCopy}
+      aria-label={label}
+      title={label}
+    >
+      {copied ? (
+        <svg
+          className={styles.icon}
+          width="16"
+          height="16"
+          viewBox="0 0 16 16"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+        >
+          <path
+            d="M13.5 4L6 11.5L2.5 8"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      ) : (
+        <svg
+          className={styles.icon}
+          width="16"
+          height="16"
+          viewBox="0 0 16 16"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+        >
+          <rect
+            x="5.5"
+            y="5.5"
+            width="8"
+            height="8"
+            rx="1.5"
+            stroke="currentColor"
+            strokeWidth="1.5"
+          />
+          <path
+            d="M10.5 5.5V3.5C10.5 2.67157 9.82843 2 9 2H3C2.17157 2 1.5 2.67157 1.5 3.5V9.5C1.5 10.3284 2.17157 11 3 11H5.5"
+            stroke="currentColor"
+            strokeWidth="1.5"
+          />
+        </svg>
+      )}
+      <span className="sr-only">{copied ? "Copied!" : label}</span>
+    </button>
+  );
+}

--- a/src/components/ui/CopyableText.module.css
+++ b/src/components/ui/CopyableText.module.css
@@ -1,0 +1,11 @@
+.container {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.monospace {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+    "Liberation Mono", monospace;
+  font-size: 0.9em;
+}

--- a/src/components/ui/CopyableText.tsx
+++ b/src/components/ui/CopyableText.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { CopyButton } from "./CopyButton";
+import styles from "./CopyableText.module.css";
+
+interface CopyableTextProps {
+  text: string;
+  displayText?: string;
+  label?: string;
+  monospace?: boolean;
+}
+
+export function CopyableText({
+  text,
+  displayText,
+  label = "Copy",
+  monospace = true,
+}: CopyableTextProps) {
+  return (
+    <span className={styles.container}>
+      <span className={monospace ? styles.monospace : undefined}>
+        {displayText || text}
+      </span>
+      <CopyButton text={text} label={label} />
+    </span>
+  );
+}


### PR DESCRIPTION
- Created reusable CopyButton component with visual feedback
- Created CopyableText component for inline text with copy functionality
- Added copy buttons to transaction hashes in PayoutsTable
- Added copy buttons to user IDs in PayoutsTable and MemberPayoutList
- Added copy button to transaction hash in payout success message
- Includes checkmark animation on successful copy
- Works in all modern browsers with clipboard API

Closes #23 

## Summary

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs
- [ ] Smart contract change

## Related issues
Closes #

## Checklist
- [ ] Tests pass (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Types pass (`npm run type-check`)
- [ ] Contract tests pass (`npm run contract:test`) if applicable
- [ ] No secrets committed
