### PR TITLE
fix: idempotent Paystack payment initialization

### DIFF
--- a/migrations/1745800000000_add-paystack-reference.ts
+++ b/migrations/1745800000000_add-paystack-reference.ts
@@ -1,0 +1,17 @@
+import { MigrationBuilder } from "node-pg-migrate";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumn("contributions", {
+    paystack_reference: { type: "varchar(255)", unique: true },
+  });
+  pgm.addConstraint(
+    "contributions",
+    "unique_contribution_per_member_cycle",
+    "UNIQUE (member_id, cycle_number)"
+  );
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropConstraint("contributions", "unique_contribution_per_member_cycle");
+  pgm.dropColumn("contributions", "paystack_reference");
+}

--- a/src/app/api/circles/[id]/contribute/__tests__/route.test.ts
+++ b/src/app/api/circles/[id]/contribute/__tests__/route.test.ts
@@ -1,0 +1,129 @@
+/**
+ * @jest-environment node
+ */
+import { POST } from "@/app/api/circles/[id]/contribute/route";
+import { NextRequest } from "next/server";
+
+jest.mock("next-auth", () => ({ getServerSession: jest.fn() }));
+jest.mock("@/lib/auth", () => ({ authOptions: {} }));
+jest.mock("@/server/services/circle.service");
+jest.mock("@/lib/paystack");
+jest.mock("@/lib/db");
+jest.mock("@/server/config", () => ({
+  serverConfig: {
+    app: { url: "http://localhost:3000" },
+    paystack: { secretKey: "test" },
+    stellar: { network: "testnet", sorobanRpcUrl: "http://localhost", ajoContractId: "test" },
+  },
+}));
+jest.mock("@/server/middleware", () => ({
+  withErrorHandler: (fn: Function) => fn,
+}));
+
+import { getServerSession } from "next-auth";
+import { getCircleById, getMembersByCircle } from "@/server/services/circle.service";
+import { initializePayment } from "@/lib/paystack";
+import * as db from "@/lib/db";
+
+const mockSession = getServerSession as jest.MockedFunction<typeof getServerSession>;
+const mockGetCircle = getCircleById as jest.MockedFunction<typeof getCircleById>;
+const mockGetMembers = getMembersByCircle as jest.MockedFunction<typeof getMembersByCircle>;
+const mockInitPayment = initializePayment as jest.MockedFunction<typeof initializePayment>;
+const mockQuery = db.query as jest.MockedFunction<typeof db.query>;
+
+const CIRCLE_ID = "circle-1";
+const MEMBER_ID = "member-1";
+const USER_ID = "user-1";
+const CYCLE = 2;
+
+const circle = {
+  id: CIRCLE_ID,
+  status: "active",
+  currentCycle: CYCLE,
+  contributionFiat: 5000,
+  contributionCurrency: "NGN",
+  contributionUsdc: "3.0000000",
+} as any;
+
+const member = { id: MEMBER_ID, userId: USER_ID } as any;
+
+function makeRequest() {
+  return new NextRequest(`http://localhost/api/circles/${CIRCLE_ID}/contribute`, { method: "POST" });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSession.mockResolvedValue({ user: { id: USER_ID, email: "user@test.com" } } as any);
+  mockGetCircle.mockResolvedValue(circle);
+  mockGetMembers.mockResolvedValue([member]);
+});
+
+describe("POST /api/circles/[id]/contribute", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockSession.mockResolvedValue(null);
+    const res = await POST(makeRequest(), { params: { id: CIRCLE_ID } });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when circle not found", async () => {
+    mockGetCircle.mockResolvedValue(null);
+    const res = await POST(makeRequest(), { params: { id: CIRCLE_ID } });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when circle is not active", async () => {
+    mockGetCircle.mockResolvedValue({ ...circle, status: "open" } as any);
+    const res = await POST(makeRequest(), { params: { id: CIRCLE_ID } });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 403 when user is not a member", async () => {
+    mockGetMembers.mockResolvedValue([]);
+    const res = await POST(makeRequest(), { params: { id: CIRCLE_ID } });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns existing authorizationUrl on duplicate (idempotent)", async () => {
+    const existingUrl = "https://paystack.com/pay/existing";
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ paystack_reference: `ajo-${CIRCLE_ID}-${MEMBER_ID}-${CYCLE}`, authorization_url: existingUrl }],
+      rowCount: 1,
+    } as any);
+
+    const res = await POST(makeRequest(), { params: { id: CIRCLE_ID } });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data.authorizationUrl).toBe(existingUrl);
+    expect(json.data.reference).toBe(`ajo-${CIRCLE_ID}-${MEMBER_ID}-${CYCLE}`);
+    expect(mockInitPayment).not.toHaveBeenCalled();
+  });
+
+  it("initializes payment and upserts contribution for new request", async () => {
+    const authUrl = "https://paystack.com/pay/new";
+    // No existing pending contribution
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 } as any);
+    // Upsert insert
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 } as any);
+    mockInitPayment.mockResolvedValue({ authorizationUrl: authUrl, reference: `ajo-${CIRCLE_ID}-${MEMBER_ID}-${CYCLE}` });
+
+    const res = await POST(makeRequest(), { params: { id: CIRCLE_ID } });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data.authorizationUrl).toBe(authUrl);
+    expect(json.data.reference).toBe(`ajo-${CIRCLE_ID}-${MEMBER_ID}-${CYCLE}`);
+
+    expect(mockInitPayment).toHaveBeenCalledWith(
+      expect.objectContaining({ reference: `ajo-${CIRCLE_ID}-${MEMBER_ID}-${CYCLE}` })
+    );
+    // Upsert query
+    expect(mockQuery).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("ON CONFLICT (member_id, cycle_number)"),
+      expect.arrayContaining([`ajo-${CIRCLE_ID}-${MEMBER_ID}-${CYCLE}`, authUrl])
+    );
+  });
+});

--- a/src/app/api/circles/[id]/contribute/route.ts
+++ b/src/app/api/circles/[id]/contribute/route.ts
@@ -5,6 +5,7 @@ import { getCircleById, getMembersByCircle } from "@/server/services/circle.serv
 import { initializePayment } from "@/lib/paystack";
 import { serverConfig } from "@/server/config";
 import { withErrorHandler } from "@/server/middleware";
+import { query } from "@/lib/db";
 import { randomUUID } from "crypto";
 import type { ApiResponse } from "@/types";
 
@@ -42,7 +43,24 @@ export const POST = withErrorHandler(async (_req: NextRequest, ctx: unknown) => 
     );
   }
 
-  const reference = `ajo-${params.id}-${circle.currentCycle}-${randomUUID().slice(0, 8)}`;
+  // Deterministic reference: ajo-{circleId}-{memberId}-{cycleNumber}
+  const reference = `ajo-${params.id}-${member.id}-${circle.currentCycle}`;
+
+  // Return existing authorizationUrl if a pending contribution already exists for this cycle
+  const { rows: existing } = await query<{ paystack_reference: string; authorization_url: string }>(
+    `SELECT paystack_reference, authorization_url
+     FROM contributions
+     WHERE member_id = $1 AND cycle_number = $2 AND status = 'pending'
+     LIMIT 1`,
+    [member.id, circle.currentCycle]
+  );
+  if (existing.length > 0 && existing[0].authorization_url) {
+    return NextResponse.json<ApiResponse<{ authorizationUrl: string; reference: string }>>({
+      success: true,
+      data: { authorizationUrl: existing[0].authorization_url, reference: existing[0].paystack_reference },
+    });
+  }
+
   const callbackUrl = `${serverConfig.app.url}/circles/${params.id}/contribute/callback?reference=${reference}`;
 
   const { authorizationUrl } = await initializePayment({
@@ -57,6 +75,16 @@ export const POST = withErrorHandler(async (_req: NextRequest, ctx: unknown) => 
       cycleNumber: circle.currentCycle,
     },
   });
+
+  // Upsert pending contribution with paystack_reference and authorization_url
+  await query(
+    `INSERT INTO contributions (id, circle_id, member_id, cycle_number, amount_usdc, status, paystack_reference, authorization_url)
+     VALUES ($1, $2, $3, $4, $5, 'pending', $6, $7)
+     ON CONFLICT (member_id, cycle_number) DO UPDATE
+       SET paystack_reference = EXCLUDED.paystack_reference,
+           authorization_url  = EXCLUDED.authorization_url`,
+    [randomUUID(), params.id, member.id, circle.currentCycle, circle.contributionUsdc, reference, authorizationUrl]
+  );
 
   return NextResponse.json<ApiResponse<{ authorizationUrl: string; reference: string }>>({
     success: true,

--- a/src/app/api/webhooks/paystack/__tests__/route.test.ts
+++ b/src/app/api/webhooks/paystack/__tests__/route.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment node
+ */
 import { POST } from "@/app/api/webhooks/paystack/route";
 import { NextRequest } from "next/server";
 import { createHmac } from "crypto";
@@ -26,7 +29,7 @@ function makeRequest(body: object, signature?: string): NextRequest {
 
 const CHARGE_SUCCESS = {
   event: "charge.success",
-  data: { reference: "ref_abc123" },
+  data: { reference: "ajo-circle-1-member-1-2" },
 };
 
 beforeEach(() => jest.clearAllMocks());
@@ -53,9 +56,7 @@ describe("POST /api/webhooks/paystack", () => {
     expect(res.status).toBe(400);
   });
 
-  it("confirms contribution on charge.success", async () => {
-    // First query: idempotency check returns no rows
-    // Second query: update contribution
+  it("confirms contribution on charge.success using paystack_reference", async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [], rowCount: 0 } as any)
       .mockResolvedValueOnce({ rows: [], rowCount: 1 } as any);
@@ -66,17 +67,17 @@ describe("POST /api/webhooks/paystack", () => {
     const json = await res.json();
     expect(json.received).toBe(true);
 
-    // Idempotency check
+    // Idempotency check uses paystack_reference
     expect(mockQuery).toHaveBeenNthCalledWith(
       1,
-      expect.stringContaining("SELECT id FROM contributions"),
-      ["ref_abc123"]
+      expect.stringContaining("paystack_reference = $1"),
+      ["ajo-circle-1-member-1-2"]
     );
-    // Confirm contribution
+    // Confirm update uses paystack_reference
     expect(mockQuery).toHaveBeenNthCalledWith(
       2,
-      expect.stringContaining("UPDATE contributions"),
-      ["ref_abc123"]
+      expect.stringContaining("paystack_reference = $1"),
+      ["ajo-circle-1-member-1-2"]
     );
   });
 
@@ -88,7 +89,6 @@ describe("POST /api/webhooks/paystack", () => {
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.duplicate).toBe(true);
-    // Only the idempotency SELECT, no UPDATE
     expect(mockQuery).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/api/webhooks/paystack/route.ts
+++ b/src/app/api/webhooks/paystack/route.ts
@@ -33,20 +33,20 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Missing reference" }, { status: 400 });
   }
 
-  // Idempotency: skip if this reference was already processed
+  // Idempotency: skip if already confirmed
   const { rows } = await query<{ id: string }>(
-    `SELECT id FROM contributions WHERE tx_hash = $1 AND status = 'confirmed' LIMIT 1`,
+    `SELECT id FROM contributions WHERE paystack_reference = $1 AND status = 'confirmed' LIMIT 1`,
     [reference]
   );
   if (rows.length > 0) {
     return NextResponse.json({ received: true, duplicate: true });
   }
 
-  // Confirm the pending contribution matching this reference
+  // Confirm the pending contribution matching this paystack_reference
   await query(
     `UPDATE contributions
      SET status = 'confirmed', tx_hash = $1
-     WHERE tx_hash = $1 AND status = 'pending'`,
+     WHERE paystack_reference = $1 AND status = 'pending'`,
     [reference]
   );
 


### PR DESCRIPTION
- Add paystack_reference column (unique) to contributions table
- Add unique constraint on (member_id, cycle_number)
- Deterministic reference: ajo-{circleId}-{memberId}-{cycleNumber}
- Return existing authorizationUrl on duplicate contribute request
- Webhook confirms contribution by paystack_reference
- Tests for contribute route and webhook

Closes #13

## Summary

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs
- [ ] Smart contract change

## Related issues
Closes #

## Checklist
- [ ] Tests pass (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Types pass (`npm run type-check`)
- [ ] Contract tests pass (`npm run contract:test`) if applicable
- [ ] No secrets committed
