### PR TITLE
test: add Paystack integration tests

### DIFF
--- a/src/app/api/circles/[id]/contribute/verify/__tests__/route.test.ts
+++ b/src/app/api/circles/[id]/contribute/verify/__tests__/route.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from "@/app/api/circles/[id]/contribute/verify/route";
+import { NextRequest } from "next/server";
+
+jest.mock("next-auth", () => ({ getServerSession: jest.fn() }));
+jest.mock("@/lib/auth", () => ({ authOptions: {} }));
+jest.mock("@/lib/paystack");
+jest.mock("@/server/services/circle.service");
+jest.mock("@/server/services/notification.service");
+jest.mock("@/server/middleware", () => ({
+  withErrorHandler: (fn: Function) => fn,
+}));
+jest.mock("@/server/config", () => ({
+  serverConfig: { paystack: { secretKey: "test" }, stellar: { network: "testnet", sorobanRpcUrl: "http://localhost", ajoContractId: "test" } },
+}));
+
+import { getServerSession } from "next-auth";
+import { verifyPayment } from "@/lib/paystack";
+import { getCircleById } from "@/server/services/circle.service";
+import { notifyContributionReceived } from "@/server/services/notification.service";
+
+const mockSession = getServerSession as jest.MockedFunction<typeof getServerSession>;
+const mockVerify = verifyPayment as jest.MockedFunction<typeof verifyPayment>;
+const mockGetCircle = getCircleById as jest.MockedFunction<typeof getCircleById>;
+const mockNotify = notifyContributionReceived as jest.MockedFunction<typeof notifyContributionReceived>;
+
+function makeRequest(params: Record<string, string>) {
+  const url = new URL("http://localhost/api/circles/c1/contribute/verify");
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  return new NextRequest(url);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockNotify.mockResolvedValue(undefined as any);
+});
+
+describe("GET /api/circles/[id]/contribute/verify", () => {
+  it("returns 400 when reference is missing", async () => {
+    const res = await GET(makeRequest({}));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.success).toBe(false);
+  });
+
+  it("returns verified payment data for a successful payment", async () => {
+    mockVerify.mockResolvedValue({ status: "success", amount: 500000, currency: "NGN" });
+    mockSession.mockResolvedValue({ user: { id: "user-1" } } as any);
+    mockGetCircle.mockResolvedValue({ name: "Test Circle", contributionUsdc: "3.0" } as any);
+
+    const res = await GET(makeRequest({ reference: "ajo-c1-m1-2", circleId: "c1", cycleNumber: "2" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data.status).toBe("success");
+    expect(json.data.amount).toBe(500000);
+  });
+
+  it("sends notification on successful payment", async () => {
+    mockVerify.mockResolvedValue({ status: "success", amount: 500000, currency: "NGN" });
+    mockSession.mockResolvedValue({ user: { id: "user-1" } } as any);
+    mockGetCircle.mockResolvedValue({ name: "Test Circle", contributionUsdc: "3.0" } as any);
+
+    await GET(makeRequest({ reference: "ajo-c1-m1-2", circleId: "c1", cycleNumber: "2" }));
+
+    // Allow async notification to fire
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockNotify).toHaveBeenCalledWith("user-1", "Test Circle", "3.0", 2);
+  });
+
+  it("returns failed status without sending notification", async () => {
+    mockVerify.mockResolvedValue({ status: "failed", amount: 500000, currency: "NGN" });
+    mockSession.mockResolvedValue({ user: { id: "user-1" } } as any);
+
+    const res = await GET(makeRequest({ reference: "ref-failed", circleId: "c1", cycleNumber: "2" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.data.status).toBe("failed");
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it("returns pending status", async () => {
+    mockVerify.mockResolvedValue({ status: "pending", amount: 0, currency: "NGN" });
+
+    const res = await GET(makeRequest({ reference: "ref-pending" }));
+    const json = await res.json();
+
+    expect(json.data.status).toBe("pending");
+  });
+
+  it("propagates Paystack API errors via error handler", async () => {
+    mockVerify.mockRejectedValue(new Error("Paystack down"));
+    await expect(GET(makeRequest({ reference: "ref-x" }))).rejects.toThrow("Paystack down");
+  });
+});

--- a/src/lib/__tests__/paystack.test.ts
+++ b/src/lib/__tests__/paystack.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock("axios", () => ({
+  create: jest.fn(() => ({ post: jest.fn(), get: jest.fn() })),
+}));
+jest.mock("@/server/config", () => ({
+  serverConfig: { paystack: { secretKey: "sk_test_secret" } },
+}));
+
+import axios from "axios";
+import { initializePayment, verifyPayment } from "@/lib/paystack";
+
+// The axios client created at module load time
+const mockClient = (axios.create as jest.Mock).mock.results[0].value as {
+  post: jest.Mock;
+  get: jest.Mock;
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("initializePayment", () => {
+  const params = {
+    email: "user@test.com",
+    amount: 5000,
+    currency: "NGN" as const,
+    reference: "ajo-circle-1-member-1-2",
+    callbackUrl: "https://ajosave.app/callback",
+  };
+
+  it("calls Paystack initialize endpoint and returns authorizationUrl + reference", async () => {
+    mockClient.post.mockResolvedValue({
+      data: {
+        data: {
+          authorization_url: "https://paystack.com/pay/abc123",
+          reference: params.reference,
+        },
+      },
+    });
+
+    const result = await initializePayment(params);
+
+    expect(mockClient.post).toHaveBeenCalledWith(
+      "/transaction/initialize",
+      expect.objectContaining({
+        email: params.email,
+        amount: 500000, // 5000 NGN → kobo
+        currency: "NGN",
+        reference: params.reference,
+        callback_url: params.callbackUrl,
+      })
+    );
+    expect(result).toEqual({
+      authorizationUrl: "https://paystack.com/pay/abc123",
+      reference: params.reference,
+    });
+  });
+
+  it("converts amount to smallest unit (kobo for NGN)", async () => {
+    mockClient.post.mockResolvedValue({
+      data: { data: { authorization_url: "https://paystack.com/pay/x", reference: "ref" } },
+    });
+
+    await initializePayment({ ...params, amount: 1000, currency: "NGN" });
+
+    expect(mockClient.post).toHaveBeenCalledWith(
+      "/transaction/initialize",
+      expect.objectContaining({ amount: 100000 }) // 1000 * 100
+    );
+  });
+
+  it("propagates Paystack API errors", async () => {
+    mockClient.post.mockRejectedValue(new Error("Network error"));
+    await expect(initializePayment(params)).rejects.toThrow("Network error");
+  });
+});
+
+describe("verifyPayment", () => {
+  it("returns success status and amount for a successful payment", async () => {
+    mockClient.get.mockResolvedValue({
+      data: {
+        data: { status: "success", amount: 500000, currency: "NGN" },
+      },
+    });
+
+    const result = await verifyPayment("ajo-circle-1-member-1-2");
+
+    expect(mockClient.get).toHaveBeenCalledWith(
+      "/transaction/verify/ajo-circle-1-member-1-2"
+    );
+    expect(result).toEqual({ status: "success", amount: 500000, currency: "NGN" });
+  });
+
+  it("returns failed status for a failed payment", async () => {
+    mockClient.get.mockResolvedValue({
+      data: { data: { status: "failed", amount: 500000, currency: "NGN" } },
+    });
+
+    const result = await verifyPayment("ref-failed");
+    expect(result.status).toBe("failed");
+  });
+
+  it("propagates Paystack API errors", async () => {
+    mockClient.get.mockRejectedValue(new Error("Unauthorized"));
+    await expect(verifyPayment("bad-ref")).rejects.toThrow("Unauthorized");
+  });
+});


### PR DESCRIPTION
- paystack.test.ts: unit tests for initializePayment and verifyPayment covering success, failed payment, amount-to-kobo conversion, and API error propagation (mocked axios client)
- verify/route.test.ts: end-to-end tests for the verify route covering missing reference (400), successful payment with notification, failed payment without notification, pending status, and API errors

Closes #105

## Summary

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs
- [ ] Smart contract change

## Related issues
Closes #

## Checklist
- [ ] Tests pass (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Types pass (`npm run type-check`)
- [ ] Contract tests pass (`npm run contract:test`) if applicable
- [ ] No secrets committed
