### PR TITLE
fix: resolve issues #7, #8, #10, #11 — users persistence, contribution tracking, double-pay guard, cron auth

### DIFF
--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -33,6 +33,7 @@ CREATE TABLE IF NOT EXISTS members (
   status VARCHAR(20) NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'active', 'rejected', 'defaulted', 'completed')),
   has_received_payout BOOLEAN NOT NULL DEFAULT FALSE,
   joined_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  reviewed_at TIMESTAMP,
   updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
   INDEX idx_members_circle_id (circle_id),
   INDEX idx_members_user_id (user_id),
@@ -48,11 +49,14 @@ CREATE TABLE IF NOT EXISTS contributions (
   cycle_number INTEGER NOT NULL CHECK (cycle_number > 0),
   amount_usdc NUMERIC(20, 7) NOT NULL,
   status VARCHAR(20) NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'confirmed', 'missed')),
+  paystack_reference VARCHAR(255) UNIQUE,
+  authorization_url TEXT,
   tx_hash VARCHAR(255),
   created_at TIMESTAMP NOT NULL DEFAULT NOW(),
   INDEX idx_contributions_circle_id (circle_id),
   INDEX idx_contributions_member_id (member_id),
-  INDEX idx_contributions_status (status)
+  INDEX idx_contributions_status (status),
+  UNIQUE KEY unique_contribution_per_cycle (member_id, cycle_number)
 );
 
 -- ─── Payouts ────────────────────────────────────────────────────────────────────

--- a/src/app/api/cron/cycle/route.ts
+++ b/src/app/api/cron/cycle/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { processDueCycles } from "@/server/services/scheduler.service";
+import { serverConfig } from "@/server/config";
 import type { ApiResponse } from "@/types";
 
 export const GET = async (req: NextRequest) => {
-  if (req.headers.get("authorization") !== `Bearer ${process.env.CRON_SECRET}`) {
+  const token = req.headers.get("authorization")?.replace("Bearer ", "");
+  if (!token || token !== serverConfig.cronSecret) {
     return NextResponse.json<ApiResponse<never>>(
       { success: false, error: "Unauthorized" },
       { status: 401 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -50,9 +50,15 @@ export const authOptions: NextAuthOptions = {
         const user = result.rows[0];
 
         if (!user) {
-          // If user doesn't exist, we might want to auto-register or return null.
-          // For now, return a placeholder to match previous behavior but with verification.
-          return { id: "new-" + phone, phone, name: "Ajosave User", role: "user" };
+          // Upsert: create user record on first successful OTP verification
+          const { rows } = await query<{ id: string; phone: string; name: string; role: string }>(
+            `INSERT INTO users (id, phone, display_name, role, reputation_score, created_at)
+             VALUES (gen_random_uuid(), $1, 'Ajosave User', 'user', 0, NOW())
+             ON CONFLICT (phone) DO UPDATE SET phone = EXCLUDED.phone
+             RETURNING id, phone, display_name as name, role`,
+            [phone]
+          );
+          return rows[0];
         }
 
         return user;

--- a/src/server/config/index.ts
+++ b/src/server/config/index.ts
@@ -29,4 +29,5 @@ export const serverConfig = {
   },
   redis: { url: process.env.REDIS_URL ?? "redis://localhost:6379" },
   database: { url: process.env.DATABASE_URL ?? "" },
+  cronSecret: process.env.CRON_SECRET ?? "",
 } as const;

--- a/src/server/services/contribution.service.ts
+++ b/src/server/services/contribution.service.ts
@@ -1,0 +1,52 @@
+import { query } from "@/lib/db";
+import { randomUUID } from "crypto";
+import type { Contribution } from "@/types";
+
+/**
+ * Create a pending contribution record for a member in a cycle.
+ * Uses ON CONFLICT to be idempotent — safe to call multiple times.
+ */
+export async function createContribution(
+  circleId: string,
+  memberId: string,
+  cycleNumber: number,
+  amountUsdc: string,
+  paystackReference: string
+): Promise<Contribution> {
+  const { rows } = await query<Contribution>(
+    `INSERT INTO contributions (id, circle_id, member_id, cycle_number, amount_usdc, status, paystack_reference, created_at)
+     VALUES ($1, $2, $3, $4, $5, 'pending', $6, NOW())
+     ON CONFLICT (member_id, cycle_number) DO UPDATE
+       SET paystack_reference = EXCLUDED.paystack_reference
+     RETURNING id, circle_id as "circleId", member_id as "memberId",
+               cycle_number as "cycleNumber", amount_usdc as "amountUsdc",
+               status, tx_hash as "txHash", created_at as "createdAt"`,
+    [randomUUID(), circleId, memberId, cycleNumber, amountUsdc, paystackReference]
+  );
+  return rows[0];
+}
+
+/**
+ * Return all members who have no confirmed contribution for the given cycle.
+ * Used by the missed-contributions cron to mark defaulters.
+ */
+export async function getMissedContributions(
+  circleId: string,
+  cycleNumber: number
+): Promise<{ memberId: string; userId: string }[]> {
+  const { rows } = await query<{ memberId: string; userId: string }>(
+    `SELECT m.id as "memberId", m.user_id as "userId"
+     FROM members m
+     WHERE m.circle_id = $1
+       AND m.status = 'active'
+       AND NOT EXISTS (
+         SELECT 1 FROM contributions c
+         WHERE c.member_id = m.id
+           AND c.circle_id = $1
+           AND c.cycle_number = $2
+           AND c.status = 'confirmed'
+       )`,
+    [circleId, cycleNumber]
+  );
+  return rows;
+}

--- a/src/server/services/payout.service.ts
+++ b/src/server/services/payout.service.ts
@@ -61,6 +61,12 @@ export async function processCyclePayout(
       parseFloat(circle.contributionUsdc) * circleMembers.length
     ).toFixed(7);
 
+    // Guard: reject if the current cycle's recipient already received a payout
+    const recipientMemberForGuard = circleMembers[circle.currentCycle - 1];
+    if (recipientMemberForGuard?.hasReceivedPayout) {
+      throw new Error(`Member has already received payout for cycle ${circle.currentCycle}`);
+    }
+
     let txHash: string;
     if (circle.contractId) {
       // Soroban path: contract handles transfer, backend only triggers payout()
@@ -85,6 +91,14 @@ export async function processCyclePayout(
     );
 
     const payout = rows[0];
+
+    // Mark recipient as having received their payout (idempotency guard)
+    if (recipientMemberId) {
+      await query(
+        "UPDATE members SET has_received_payout = TRUE WHERE id = $1",
+        [recipientMemberId]
+      );
+    }
 
     // Send SMS notifications to all members
     if (recipientMember) {

--- a/src/server/services/scheduler.service.ts
+++ b/src/server/services/scheduler.service.ts
@@ -1,5 +1,6 @@
 import { query } from "@/lib/db";
 import { notifyPayoutReminder, notifyMissedContribution } from "./notification.service";
+import { getMissedContributions } from "./contribution.service";
 import type { Circle, Member } from "@/types";
 
 /**
@@ -64,45 +65,25 @@ export async function processMissedContributions(): Promise<void> {
 
   for (const circle of circles) {
     try {
-      // Get all active members
-      const { rows: members } = await query<Member>(
-        "SELECT * FROM members WHERE circle_id = $1 AND status = 'active'",
-        [circle.id]
-      );
+      const missed = await getMissedContributions(circle.id, circle.currentCycle);
 
-      // Check which members haven't contributed for the current cycle
-      for (const member of members) {
-        const { rows: contributions } = await query(
-          `SELECT * FROM contributions 
-           WHERE circle_id = $1 
-           AND member_id = $2 
-           AND cycle_number = $3 
-           AND status = 'confirmed'`,
-          [circle.id, member.id, circle.currentCycle]
+      for (const { memberId, userId } of missed) {
+        // Mark member as defaulted
+        await query(
+          "UPDATE members SET status = 'defaulted' WHERE id = $1",
+          [memberId]
         );
 
-        // If no confirmed contribution, mark as missed
-        if (contributions.length === 0) {
-          // Mark member as defaulted
-          await query(
-            "UPDATE members SET status = 'defaulted' WHERE id = $1",
-            [member.id]
-          );
+        // Create missed contribution record
+        await query(
+          `INSERT INTO contributions (id, circle_id, member_id, cycle_number, amount_usdc, status, created_at)
+           VALUES (gen_random_uuid(), $1, $2, $3, $4, 'missed', NOW())
+           ON CONFLICT (member_id, cycle_number) DO NOTHING`,
+          [circle.id, memberId, circle.currentCycle, circle.contributionUsdc]
+        );
 
-          // Create missed contribution record
-          await query(
-            `INSERT INTO contributions (id, circle_id, member_id, cycle_number, amount_usdc, status, created_at)
-             VALUES (gen_random_uuid(), $1, $2, $3, $4, 'missed', NOW())`,
-            [circle.id, member.id, circle.currentCycle, circle.contributionUsdc]
-          );
-
-          // Send notification
-          await notifyMissedContribution(
-            member.userId,
-            circle.name,
-            circle.contributionUsdc
-          );
-        }
+        // Send notification
+        await notifyMissedContribution(userId, circle.name, circle.contributionUsdc);
       }
     } catch (error) {
       console.error(`Failed to process missed contributions for circle ${circle.id}:`, error);


### PR DESCRIPTION
## Summary

This PR fixes four backend issues in a single pass. All changes are minimal and targeted.

---

### #7 — Persist user records to PostgreSQL

**Problem:** On successful OTP verification, the `authorize` callback returned a placeholder `{ id: "new-" + phone }` when no user row existed. Session user IDs were never real DB records.

**Fix:** Replace the placeholder with an `INSERT … ON CONFLICT (phone) DO UPDATE` upsert in `src/lib/auth.ts`. The first successful OTP verification now creates a real `users` row; subsequent logins return the existing row.

---

### #8 — Implement contribution tracking per cycle

**Problem:** The `Contribution` type existed but there was no service layer. The `processMissedContributions` scheduler duplicated raw SQL inline.

**Fix:**
- New `src/server/services/contribution.service.ts` with:
  - `createContribution` — idempotent upsert via `ON CONFLICT (member_id, cycle_number)`
  - `getMissedContributions` — single `NOT EXISTS` query returning members with no confirmed contribution for a cycle
- `scheduler.service.ts` refactored to call `getMissedContributions` instead of duplicating the SQL
- `docs/schema.sql` updated: `contributions` table gains `paystack_reference UNIQUE`, `authorization_url`, and `UNIQUE KEY unique_contribution_per_cycle (member_id, cycle_number)`

---

### #10 — Add payout double-pay guard

**Problem:** `processCyclePayout` never checked `hasReceivedPayout` before sending, and never set it to `true` after a successful payout. Duplicate cron triggers could pay the same member twice.

**Fix:**
- Guard added at the top of `processCyclePayout`: throws if `recipientMember.hasReceivedPayout === true`
- After the payout record is persisted: `UPDATE members SET has_received_payout = TRUE WHERE id = $1`

---

### #11 — Cron job authentication

**Problem:** `/api/cron/cycle` read `process.env.CRON_SECRET` directly, bypassing `serverConfig`. The other two cron routes (`/missed-contributions`, `/reminders`) already used `serverConfig.cronSecret`, which didn't exist — so they always compared against `undefined`.

**Fix:**
- `serverConfig` gains `cronSecret: process.env.CRON_SECRET ?? ""`
- `/api/cron/cycle/route.ts` updated to use `serverConfig.cronSecret` (consistent with the other cron routes)

---

## Files changed

| File | Issue |
|------|-------|
| `src/lib/auth.ts` | #7 |
| `src/server/services/contribution.service.ts` (new) | #8 |
| `src/server/services/scheduler.service.ts` | #8 |
| `docs/schema.sql` | #8 |
| `src/server/services/payout.service.ts` | #10 |
| `src/server/config/index.ts` | #11 |
| `src/app/api/cron/cycle/route.ts` | #11 |

## Testing

- Existing payout service tests continue to pass (guard only fires when `hasReceivedPayout` is `true`, which the test fixtures default to `false`)
- No new external dependencies introduced

Closes #7
Closes #8
Closes #10
Closes #11