### PR TITLE
feat: add page-level loading.tsx skeleton UIs

### DIFF
--- a/src/app/circles/[id]/loading.tsx
+++ b/src/app/circles/[id]/loading.tsx
@@ -1,0 +1,37 @@
+import styles from "./page.module.css";
+
+export default function CircleDetailLoading() {
+  return (
+    <div className={styles.page}>
+      <div className="container">
+        <div className={styles.header}>
+          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+            <div className="skeleton" style={{ width: 240, height: 32, borderRadius: "var(--radius-md)" }} />
+            <div className="skeleton" style={{ width: 72, height: 22, borderRadius: "var(--radius-full)" }} />
+          </div>
+        </div>
+        <div className={styles.grid}>
+          <div className="card" style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
+            <div className="skeleton" style={{ width: 140, height: 20, borderRadius: "var(--radius-sm)" }} />
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} style={{ display: "flex", justifyContent: "space-between" }}>
+                <div className="skeleton" style={{ width: "35%", height: 16, borderRadius: "var(--radius-sm)" }} />
+                <div className="skeleton" style={{ width: "45%", height: 16, borderRadius: "var(--radius-sm)" }} />
+              </div>
+            ))}
+          </div>
+          <div className="card" style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
+            <div className="skeleton" style={{ width: 120, height: 20, borderRadius: "var(--radius-sm)" }} />
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} style={{ display: "flex", alignItems: "center", gap: "var(--space-3)" }}>
+                <div className="skeleton" style={{ width: 32, height: 32, borderRadius: "var(--radius-full)" }} />
+                <div className="skeleton" style={{ flex: 1, height: 16, borderRadius: "var(--radius-sm)" }} />
+                <div className="skeleton" style={{ width: 64, height: 22, borderRadius: "var(--radius-full)" }} />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/circles/loading.tsx
+++ b/src/app/circles/loading.tsx
@@ -1,0 +1,24 @@
+import styles from "./page.module.css";
+
+export default function CirclesLoading() {
+  return (
+    <div className={styles.page}>
+      <div className="container">
+        <div className={styles.header}>
+          <div className="skeleton" style={{ width: 160, height: 32, borderRadius: "var(--radius-md)" }} />
+          <div className="skeleton" style={{ width: 120, height: 36, borderRadius: "var(--radius-md)" }} />
+        </div>
+        <div className={styles.grid}>
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="card" style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
+              <div className="skeleton" style={{ width: "60%", height: 20, borderRadius: "var(--radius-sm)" }} />
+              <div className="skeleton" style={{ width: "40%", height: 16, borderRadius: "var(--radius-sm)" }} />
+              <div className="skeleton" style={{ width: "80%", height: 16, borderRadius: "var(--radius-sm)" }} />
+              <div className="skeleton" style={{ width: 100, height: 32, borderRadius: "var(--radius-md)", marginTop: "var(--space-2)" }} />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/loading.tsx
+++ b/src/app/dashboard/loading.tsx
@@ -1,0 +1,23 @@
+import styles from "./page.module.css";
+
+export default function DashboardLoading() {
+  return (
+    <div className={styles.page}>
+      <div className="container">
+        <div className="skeleton" style={{ width: 200, height: 32, borderRadius: "var(--radius-md)", marginBottom: "var(--space-8)" }} />
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="card" style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                <div className="skeleton" style={{ width: "50%", height: 20, borderRadius: "var(--radius-sm)" }} />
+                <div className="skeleton" style={{ width: 64, height: 22, borderRadius: "var(--radius-full)" }} />
+              </div>
+              <div className="skeleton" style={{ width: "70%", height: 16, borderRadius: "var(--radius-sm)" }} />
+              <div className="skeleton" style={{ width: "40%", height: 16, borderRadius: "var(--radius-sm)" }} />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -39,3 +39,20 @@ ul, ol { list-style: none; }
   outline-offset: 2px;
   border-radius: var(--radius-sm);
 }
+
+/* ─── Skeleton loader ─────────────────────────────────────────────────────── */
+.skeleton {
+  background: linear-gradient(
+    90deg,
+    var(--color-bg-elevated) 25%,
+    var(--color-border) 50%,
+    var(--color-bg-elevated) 75%
+  );
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.4s ease infinite;
+}
+
+@keyframes skeleton-shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}


### PR DESCRIPTION
## Summary

Adds Next.js App Router `loading.tsx` files to all three routes that were missing them, plus a shared `.skeleton` shimmer utility.

## Type of change
- [x] New feature

## Related issues
Closes #63

## Changes
- `src/app/circles/loading.tsx` — grid of 6 skeleton cards matching CircleCard layout
- `src/app/dashboard/loading.tsx` — list of 3 skeleton circle rows
- `src/app/circles/[id]/loading.tsx` — two-column skeleton matching detail + member list
- `src/styles/globals.css` — `.skeleton` shimmer animation utility

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Types pass (`npm run type-check`)
- [x] No secrets committed