### PR TITLE
feat: implement user profile page

### DIFF
--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,0 +1,119 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { query } from "@/lib/db";
+import { z } from "zod";
+import type { ApiResponse } from "@/types";
+
+const updateSchema = z.object({
+  displayName: z.string().min(1).max(80).optional(),
+  email: z.string().email().optional().or(z.literal("")),
+  stellarPublicKey: z
+    .string()
+    .regex(/^G[A-Z2-7]{55}$/, "Invalid Stellar public key")
+    .optional()
+    .or(z.literal("")),
+});
+
+export type ProfileData = {
+  id: string;
+  phone: string;
+  displayName: string;
+  email: string | null;
+  stellarPublicKey: string | null;
+  reputationScore: number;
+  contributionStats: {
+    total: number;
+    confirmed: number;
+    missed: number;
+  };
+};
+
+export async function GET(): Promise<NextResponse<ApiResponse<ProfileData>>> {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { rows } = await query<{
+    id: string;
+    phone: string;
+    display_name: string;
+    email: string | null;
+    stellar_public_key: string | null;
+    reputation_score: number;
+    total: string;
+    confirmed: string;
+    missed: string;
+  }>(
+    `SELECT
+       u.id, u.phone, u.display_name, u.email, u.stellar_public_key, u.reputation_score,
+       COUNT(c.id)                                          AS total,
+       COUNT(c.id) FILTER (WHERE c.status = 'confirmed')   AS confirmed,
+       COUNT(c.id) FILTER (WHERE c.status = 'missed')      AS missed
+     FROM users u
+     LEFT JOIN members m ON m.user_id = u.id
+     LEFT JOIN contributions c ON c.member_id = m.id
+     WHERE u.id = $1
+     GROUP BY u.id`,
+    [session.user.id]
+  );
+
+  if (!rows[0]) {
+    return NextResponse.json({ success: false, error: "User not found" }, { status: 404 });
+  }
+
+  const row = rows[0];
+  return NextResponse.json({
+    success: true,
+    data: {
+      id: row.id,
+      phone: row.phone,
+      displayName: row.display_name,
+      email: row.email,
+      stellarPublicKey: row.stellar_public_key,
+      reputationScore: row.reputation_score,
+      contributionStats: {
+        total: Number(row.total),
+        confirmed: Number(row.confirmed),
+        missed: Number(row.missed),
+      },
+    },
+  });
+}
+
+export async function PATCH(
+  req: NextRequest
+): Promise<NextResponse<ApiResponse<{ updated: true }>>> {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const parsed = updateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, error: parsed.error.errors[0].message },
+      { status: 400 }
+    );
+  }
+
+  const { displayName, email, stellarPublicKey } = parsed.data;
+
+  await query(
+    `UPDATE users
+     SET display_name        = COALESCE($1, display_name),
+         email               = COALESCE($2, email),
+         stellar_public_key  = COALESCE($3, stellar_public_key)
+     WHERE id = $4`,
+    [
+      displayName ?? null,
+      email !== undefined ? (email === "" ? null : email) : null,
+      stellarPublicKey !== undefined ? (stellarPublicKey === "" ? null : stellarPublicKey) : null,
+      session.user.id,
+    ]
+  );
+
+  return NextResponse.json({ success: true, data: { updated: true } });
+}

--- a/src/app/profile/page.module.css
+++ b/src/app/profile/page.module.css
@@ -1,0 +1,162 @@
+.page { padding: var(--space-12) 0; }
+
+.title {
+  font-size: var(--text-2xl);
+  font-weight: var(--font-bold);
+  color: var(--color-text-primary);
+  margin-bottom: var(--space-6);
+}
+
+.sectionTitle {
+  font-size: var(--text-lg);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+  margin-bottom: var(--space-4);
+}
+
+/* ── Reputation ── */
+.reputationRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-6);
+}
+
+.scoreCircle {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 80px;
+  height: 80px;
+  border-radius: var(--radius-full);
+  border: 3px solid var(--color-brand-primary);
+  flex-shrink: 0;
+}
+
+.scoreCircle[data-level="excellent"] { border-color: var(--color-success); }
+.scoreCircle[data-level="good"]      { border-color: var(--color-brand-primary); }
+.scoreCircle[data-level="fair"]      { border-color: var(--color-warning); }
+.scoreCircle[data-level="building"]  { border-color: var(--color-text-muted); }
+
+.scoreNumber {
+  font-size: var(--text-2xl);
+  font-weight: var(--font-bold);
+  color: var(--color-text-primary);
+  line-height: 1;
+}
+
+.scoreMax {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+.reputationMeta {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.reputationLabel {
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-secondary);
+}
+
+.progressBar {
+  height: 8px;
+  background: var(--color-bg-elevated);
+  border-radius: var(--radius-full);
+  overflow: hidden;
+}
+
+.progressFill {
+  height: 100%;
+  background: var(--color-brand-primary);
+  border-radius: var(--radius-full);
+  transition: width var(--transition-base);
+}
+
+/* ── Stats ── */
+.statsGrid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-4);
+}
+
+@media (max-width: 600px) {
+  .statsGrid { grid-template-columns: repeat(2, 1fr); }
+}
+
+.statItem {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-4);
+  background: var(--color-bg-elevated);
+  border-radius: var(--radius-lg);
+}
+
+.statValue {
+  font-size: var(--text-2xl);
+  font-weight: var(--font-bold);
+  color: var(--color-text-primary);
+}
+
+.statLabel {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* ── Form ── */
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  max-width: 480px;
+}
+
+.message {
+  font-size: var(--text-sm);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+}
+
+.success {
+  background: rgba(34, 197, 94, 0.1);
+  color: var(--color-success);
+  border: 1px solid rgba(34, 197, 94, 0.3);
+}
+
+.error {
+  background: rgba(239, 68, 68, 0.1);
+  color: var(--color-error);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+}
+
+/* ── Skeleton ── */
+.skeleton_title {
+  width: 200px;
+  height: 32px;
+  border-radius: var(--radius-md);
+  margin-bottom: var(--space-6);
+  background: linear-gradient(90deg, var(--color-bg-elevated) 25%, var(--color-border) 50%, var(--color-bg-elevated) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.4s ease infinite;
+}
+
+.skeleton_card {
+  height: 200px;
+  border-radius: var(--radius-xl);
+  background: linear-gradient(90deg, var(--color-bg-elevated) 25%, var(--color-border) 50%, var(--color-bg-elevated) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.4s ease infinite;
+}
+
+@keyframes shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import styles from "./page.module.css";
+import type { ProfileData } from "@/app/api/profile/route";
+
+export default function ProfilePage() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+
+  const [profile, setProfile] = useState<ProfileData | null>(null);
+  const [form, setForm] = useState({ displayName: "", email: "", stellarPublicKey: "" });
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+
+  useEffect(() => {
+    if (status === "unauthenticated") router.push("/auth/login");
+  }, [status, router]);
+
+  useEffect(() => {
+    if (status !== "authenticated") return;
+    fetch("/api/profile")
+      .then((r) => r.json())
+      .then((json) => {
+        if (json.success) {
+          setProfile(json.data);
+          setForm({
+            displayName: json.data.displayName ?? "",
+            email: json.data.email ?? "",
+            stellarPublicKey: json.data.stellarPublicKey ?? "",
+          });
+        }
+      });
+  }, [status]);
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    setMessage(null);
+    try {
+      const res = await fetch("/api/profile", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(form),
+      });
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error);
+      setMessage({ type: "success", text: "Profile updated." });
+      setProfile((p) => p && { ...p, ...form });
+    } catch (err) {
+      setMessage({ type: "error", text: err instanceof Error ? err.message : "Save failed." });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (status === "loading" || !profile) {
+    return (
+      <div className={styles.page}>
+        <div className="container">
+          <div className={styles.skeleton_title} />
+          <div className={styles.skeleton_card} />
+        </div>
+      </div>
+    );
+  }
+
+  const { reputationScore, contributionStats } = profile;
+  const reputationLabel =
+    reputationScore >= 80 ? "Excellent" :
+    reputationScore >= 60 ? "Good" :
+    reputationScore >= 40 ? "Fair" : "Building";
+
+  return (
+    <div className={styles.page}>
+      <div className="container">
+        <h1 className={styles.title}>My Profile</h1>
+
+        {/* ── Reputation ── */}
+        <section className="card" style={{ marginBottom: "var(--space-6)" }}>
+          <h2 className={styles.sectionTitle}>Reputation Score</h2>
+          <div className={styles.reputationRow}>
+            <div className={styles.scoreCircle} data-level={reputationLabel.toLowerCase()}>
+              <span className={styles.scoreNumber}>{reputationScore}</span>
+              <span className={styles.scoreMax}>/100</span>
+            </div>
+            <div className={styles.reputationMeta}>
+              <span className={styles.reputationLabel}>{reputationLabel}</span>
+              <div className={styles.progressBar}>
+                <div className={styles.progressFill} style={{ width: `${reputationScore}%` }} />
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Contribution history ── */}
+        <section className="card" style={{ marginBottom: "var(--space-6)" }}>
+          <h2 className={styles.sectionTitle}>Contribution History</h2>
+          <div className={styles.statsGrid}>
+            <div className={styles.statItem}>
+              <span className={styles.statValue}>{contributionStats.total}</span>
+              <span className={styles.statLabel}>Total</span>
+            </div>
+            <div className={styles.statItem}>
+              <span className={styles.statValue} style={{ color: "var(--color-success)" }}>
+                {contributionStats.confirmed}
+              </span>
+              <span className={styles.statLabel}>Confirmed</span>
+            </div>
+            <div className={styles.statItem}>
+              <span className={styles.statValue} style={{ color: "var(--color-error)" }}>
+                {contributionStats.missed}
+              </span>
+              <span className={styles.statLabel}>Missed</span>
+            </div>
+            <div className={styles.statItem}>
+              <span className={styles.statValue}>
+                {contributionStats.total > 0
+                  ? `${Math.round((contributionStats.confirmed / contributionStats.total) * 100)}%`
+                  : "—"}
+              </span>
+              <span className={styles.statLabel}>On-time rate</span>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Editable fields ── */}
+        <section className="card">
+          <h2 className={styles.sectionTitle}>Edit Profile</h2>
+          <form onSubmit={handleSave} className={styles.form}>
+            <div className="input-group">
+              <label className="input-label" htmlFor="phone">Phone</label>
+              <input id="phone" className="input" value={profile.phone} disabled aria-disabled="true" />
+            </div>
+            <div className="input-group">
+              <label className="input-label" htmlFor="displayName">Display Name</label>
+              <input
+                id="displayName"
+                className="input"
+                value={form.displayName}
+                onChange={(e) => setForm((f) => ({ ...f, displayName: e.target.value }))}
+                maxLength={80}
+                placeholder="Your name"
+              />
+            </div>
+            <div className="input-group">
+              <label className="input-label" htmlFor="email">Email</label>
+              <input
+                id="email"
+                type="email"
+                className="input"
+                value={form.email}
+                onChange={(e) => setForm((f) => ({ ...f, email: e.target.value }))}
+                placeholder="you@example.com"
+              />
+            </div>
+            <div className="input-group">
+              <label className="input-label" htmlFor="stellarPublicKey">Stellar Public Key</label>
+              <input
+                id="stellarPublicKey"
+                className="input"
+                value={form.stellarPublicKey}
+                onChange={(e) => setForm((f) => ({ ...f, stellarPublicKey: e.target.value }))}
+                placeholder="GXXXXXXX…"
+                spellCheck={false}
+              />
+            </div>
+
+            {message && (
+              <p className={`${styles.message} ${styles[message.type]}`} role="status">
+                {message.text}
+              </p>
+            )}
+
+            <button type="submit" className="btn btn--primary" disabled={saving}>
+              {saving ? <span className="btn-spinner" aria-hidden="true" /> : null}
+              {saving ? "Saving…" : "Save Changes"}
+            </button>
+          </form>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -18,7 +18,10 @@ export async function Navbar() {
           <li><Link href="/circles" className={styles.link}>Browse Circles</Link></li>
           <li><Link href="/dashboard" className={styles.link}>Dashboard</Link></li>
           {isAdmin && <li><Link href="/admin" className={styles.link}>Admin</Link></li>}
-          <li><Link href="/auth/login" className="btn btn--primary btn--sm">Sign In</Link></li>
+          {session?.user
+            ? <li><Link href="/profile" className={styles.link}>Profile</Link></li>
+            : <li><Link href="/auth/login" className="btn btn--primary btn--sm">Sign In</Link></li>
+          }
         </ul>
       </nav>
     </header>


### PR DESCRIPTION
## Summary

Adds a `/profile` route where authenticated users can view and edit their display name, email, and Stellar public key, see their reputation score with a visual indicator, and review their contribution history summary.

## Type of change
- [x] New feature

## Related issues
Closes #57

## Changes
- `src/app/profile/page.tsx` — client component with editable form, reputation score, contribution stats
- `src/app/profile/page.module.css` — styles matching the existing design system
- `src/app/api/profile/route.ts` — GET (fetch profile + stats) and PATCH (update fields) API routes
- `src/components/layout/Navbar.tsx` — Profile link shown to authenticated users

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Types pass (`npm run type-check`)
- [x] No secrets committed