### PR TITLE
feat: add NGN/USDC conversion preview in CreateCircleForm

### DIFF
--- a/src/app/api/fx/rate/route.ts
+++ b/src/app/api/fx/rate/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { getNgnPerUsdc } from "@/lib/fx";
+import type { ApiResponse } from "@/types";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const rate = await getNgnPerUsdc();
+    return NextResponse.json<ApiResponse<{ ngnPerUsdc: number; fetchedAt: string }>>({
+      success: true,
+      data: { ngnPerUsdc: rate, fetchedAt: new Date().toISOString() },
+    });
+  } catch {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Failed to fetch FX rate" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/circle/CreateCircleForm.module.css
+++ b/src/components/circle/CreateCircleForm.module.css
@@ -1,3 +1,5 @@
 .form { display: flex; flex-direction: column; gap: var(--space-5); width: 100%; max-width: 480px; }
 .title { font-size: var(--text-2xl); font-weight: var(--font-bold); color: var(--color-text-primary); }
 .error { font-size: var(--text-sm); color: var(--color-error); background: rgba(239,68,68,0.1); border: 1px solid rgba(239,68,68,0.3); border-radius: var(--radius-md); padding: var(--space-3) var(--space-4); }
+.usdcPreview { font-size: var(--text-sm); color: var(--color-brand-primary); margin-top: calc(var(--space-2) * -1); }
+.rateSource { font-size: var(--text-xs); color: var(--color-text-muted); }

--- a/src/components/circle/CreateCircleForm.tsx
+++ b/src/components/circle/CreateCircleForm.tsx
@@ -1,26 +1,59 @@
 "use client";
 
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { createCircleSchema, type CreateCircleInput } from "@/types/schemas";
 import { Input } from "@/components/ui/Input";
 import { Button } from "@/components/ui/Button";
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import styles from "./CreateCircleForm.module.css";
+
+function useUsdcPreview(ngnAmount: number | undefined) {
+  const [usdc, setUsdc] = useState<number | null>(null);
+  const [fetchedAt, setFetchedAt] = useState<string | null>(null);
+  const rateRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!rateRef.current) {
+      fetch("/api/fx/rate")
+        .then((r) => r.json())
+        .then((json) => {
+          if (json.success) {
+            rateRef.current = json.data.ngnPerUsdc;
+            setFetchedAt(json.data.fetchedAt);
+          }
+        })
+        .catch(() => {});
+    }
+  }, []);
+
+  useEffect(() => {
+    if (rateRef.current && ngnAmount && ngnAmount > 0) {
+      setUsdc(ngnAmount / rateRef.current);
+    } else {
+      setUsdc(null);
+    }
+  }, [ngnAmount]);
+
+  return { usdc, fetchedAt };
+}
 
 export function CreateCircleForm() {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const { register, handleSubmit, formState: { errors } } = useForm<CreateCircleInput>({
+  const { register, handleSubmit, control, formState: { errors } } = useForm<CreateCircleInput>({
     resolver: zodResolver(createCircleSchema),
     defaultValues: { 
       cycleFrequency: "monthly",
       circleType: "public"
     },
   });
+
+  const ngnAmount = useWatch({ control, name: "contributionNgn" });
+  const { usdc, fetchedAt } = useUsdcPreview(ngnAmount);
 
   const onSubmit = async (data: CreateCircleInput) => {
     setLoading(true);
@@ -51,6 +84,17 @@ export function CreateCircleForm() {
       <Input label="Contribution Amount (₦)" type="number" placeholder="10000"
         error={errors.contributionNgn?.message}
         {...register("contributionNgn", { valueAsNumber: true })} />
+
+      {usdc !== null && (
+        <p className={styles.usdcPreview}>
+          ≈ <strong>{usdc.toFixed(2)} USDC</strong>
+          {fetchedAt && (
+            <span className={styles.rateSource}>
+              {" "}· Rate from open.er-api.com · {new Date(fetchedAt).toLocaleTimeString()}
+            </span>
+          )}
+        </p>
+      )}
 
       <Input label="Number of Members" type="number" placeholder="5" min={2} max={20}
         error={errors.maxMembers?.message}


### PR DESCRIPTION
Closes #68

## Changes
- Add `/api/fx/rate` endpoint wrapping the existing `getNgnPerUsdc()` server function
- In `CreateCircleForm`, fetch the rate once on mount via `useRef` to avoid re-fetching on every keystroke
- Use `useWatch` to reactively compute USDC equivalent as the NGN amount changes
- Display `≈ X.XX USDC` with rate source (open.er-api.com) and timestamp below the amount field

## Acceptance Criteria
- [x] USDC preview updates as NGN input changes
- [x] Uses current exchange rate from API
- [x] Shows rate source and timestamp