### PR TITLE
feat: add meta tags and Open Graph for social sharing

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="8" fill="#0f7a4a"/>
+  <text x="16" y="22" font-size="18" text-anchor="middle" fill="#f5a623" font-family="system-ui,sans-serif" font-weight="bold">A</text>
+</svg>

--- a/public/og-default.svg
+++ b/public/og-default.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <rect width="1200" height="630" fill="#080f0b"/>
+  <rect x="0" y="0" width="1200" height="630" fill="url(#grad)"/>
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0e1a12"/>
+      <stop offset="100%" style="stop-color:#080f0b"/>
+    </linearGradient>
+  </defs>
+  <!-- Logo circle -->
+  <rect x="80" y="80" width="80" height="80" rx="20" fill="#0f7a4a"/>
+  <text x="120" y="140" font-size="52" text-anchor="middle" fill="#f5a623" font-family="system-ui,sans-serif" font-weight="bold">A</text>
+  <!-- Title -->
+  <text x="80" y="300" font-size="72" fill="#eef5f0" font-family="system-ui,sans-serif" font-weight="bold">Ajosave</text>
+  <!-- Subtitle -->
+  <text x="80" y="380" font-size="36" fill="#8aab94" font-family="system-ui,sans-serif">Trustless rotating savings on Stellar</text>
+  <!-- Tag line -->
+  <text x="80" y="450" font-size="28" fill="#4a6655" font-family="system-ui,sans-serif">Contribute in Naira · Receive in USDC · No middleman</text>
+  <!-- Bottom accent -->
+  <rect x="80" y="520" width="120" height="4" rx="2" fill="#0f7a4a"/>
+  <rect x="220" y="520" width="60" height="4" rx="2" fill="#f5a623"/>
+</svg>

--- a/src/app/circles/[id]/page.tsx
+++ b/src/app/circles/[id]/page.tsx
@@ -14,7 +14,29 @@ interface Props {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const circle = await getCircleById(params.id);
-  return { title: circle?.name ?? "Circle" };
+  if (!circle) return { title: "Circle Not Found" };
+
+  const title = `${circle.name} | Ajosave`;
+  const description = `Join ${circle.name} — a savings circle with ₦${circle.contributionNgn.toLocaleString("en-NG")} contributions every ${circle.cycleFrequency}. Powered by Stellar.`;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url: `https://www.ajosave.app/circles/${params.id}`,
+      siteName: "Ajosave",
+      type: "website",
+      images: [{ url: "/og-default.svg", width: 1200, height: 630, alt: title }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: ["/og-default.svg"],
+    },
+  };
 }
 
 export default async function CircleDetailPage({ params }: Props) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,14 +13,25 @@ export const metadata: Metadata = {
   title: { default: "Ajosave — On-Chain Rotating Savings on Stellar", template: "%s | Ajosave" },
   description: "Join or create trustless savings circles (Ajo/Esusu) powered by Stellar Soroban smart contracts and USDC.",
   keywords: ["ajo", "esusu", "savings", "stellar", "soroban", "usdc", "nigeria", "defi"],
+  metadataBase: new URL("https://www.ajosave.app"),
   openGraph: {
     title: "Ajosave — On-Chain Rotating Savings",
-    description: "Trustless Ajo/Esusu savings circles on Stellar.",
+    description: "Trustless Ajo/Esusu savings circles on Stellar. Contribute in Naira, receive in USDC.",
     url: "https://www.ajosave.app",
     siteName: "Ajosave",
     type: "website",
+    images: [{ url: "/og-default.svg", width: 1200, height: 630, alt: "Ajosave — Trustless rotating savings on Stellar" }],
   },
-  twitter: { card: "summary_large_image", title: "Ajosave", description: "Trustless rotating savings on Stellar." },
+  twitter: {
+    card: "summary_large_image",
+    title: "Ajosave — On-Chain Rotating Savings",
+    description: "Trustless Ajo/Esusu savings circles on Stellar. Contribute in Naira, receive in USDC.",
+    images: ["/og-default.svg"],
+  },
+  icons: {
+    icon: "/favicon.svg",
+    shortcut: "/favicon.svg",
+  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
Closes #65

## Changes
- **Root layout** — added `metadataBase`, OG `images` array, Twitter card `images`, and `icons` (favicon) to the existing metadata object
- **public/favicon.svg** — SVG favicon with brand green background and gold "A"
- **public/og-default.svg** — 1200×630 OG image with brand colors, app name, and tagline
- **Circle detail page** — `generateMetadata` now returns dynamic `title`, `description`, `openGraph`, and `twitter` fields using the circle's name and contribution details

## Acceptance Criteria
- [x] Default OG tags in root layout.tsx
- [x] Dynamic OG tags for circle detail pages
- [x] Twitter card meta tags
- [x] Favicon set