### PR TITLE
feat: add PWA manifest and service worker

### DIFF
--- a/public/icons/icon-192.svg
+++ b/public/icons/icon-192.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
+  <rect width="192" height="192" rx="40" fill="#0f7a4a"/>
+  <text x="96" y="130" font-size="110" text-anchor="middle" fill="#f5a623" font-family="system-ui,sans-serif" font-weight="bold">A</text>
+</svg>

--- a/public/icons/icon-512.svg
+++ b/public/icons/icon-512.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="100" fill="#0f7a4a"/>
+  <text x="256" y="350" font-size="300" text-anchor="middle" fill="#f5a623" font-family="system-ui,sans-serif" font-weight="bold">A</text>
+</svg>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,78 @@
+const CACHE_NAME = "ajosave-v1";
+
+// Static assets to pre-cache on install
+const PRECACHE_URLS = [
+  "/",
+  "/circles",
+  "/dashboard",
+  "/offline",
+  "/favicon.svg",
+  "/icons/icon-192.svg",
+  "/icons/icon-512.svg",
+];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)))
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  // Only handle same-origin GET requests
+  if (request.method !== "GET" || url.origin !== self.location.origin) return;
+
+  // Network-first for API routes
+  if (url.pathname.startsWith("/api/")) {
+    event.respondWith(
+      fetch(request).catch(() =>
+        new Response(JSON.stringify({ success: false, error: "Offline" }), {
+          headers: { "Content-Type": "application/json" },
+        })
+      )
+    );
+    return;
+  }
+
+  // Cache-first for static assets (_next/static, icons, images)
+  if (
+    url.pathname.startsWith("/_next/static/") ||
+    url.pathname.startsWith("/icons/") ||
+    url.pathname.endsWith(".svg") ||
+    url.pathname.endsWith(".png") ||
+    url.pathname.endsWith(".ico")
+  ) {
+    event.respondWith(
+      caches.match(request).then((cached) => cached ?? fetch(request).then((res) => {
+        const clone = res.clone();
+        caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
+        return res;
+      }))
+    );
+    return;
+  }
+
+  // Stale-while-revalidate for pages
+  event.respondWith(
+    caches.match(request).then((cached) => {
+      const network = fetch(request).then((res) => {
+        const clone = res.clone();
+        caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
+        return res;
+      }).catch(() => cached ?? caches.match("/offline"));
+      return cached ?? network;
+    })
+  );
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
 import { SessionProvider } from "next-auth/react";
 import { SentryUserContext } from "@/components/SentryUserContext";
+import { PWAProvider } from "@/components/PWAProvider";
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
 
@@ -32,6 +33,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <Navbar />
           <main>{children}</main>
           <Footer />
+          <PWAProvider />
         </SessionProvider>
       </body>
     </html>

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from "next";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "Ajosave — Rotating Savings on Stellar",
+    short_name: "Ajosave",
+    description: "Trustless Ajo/Esusu savings circles powered by Stellar and USDC.",
+    start_url: "/",
+    display: "standalone",
+    background_color: "#080f0b",
+    theme_color: "#0f7a4a",
+    orientation: "portrait",
+    icons: [
+      { src: "/icons/icon-192.svg", sizes: "192x192", type: "image/svg+xml", purpose: "any maskable" },
+      { src: "/icons/icon-512.svg", sizes: "512x512", type: "image/svg+xml", purpose: "any maskable" },
+    ],
+    categories: ["finance", "utilities"],
+    screenshots: [],
+  };
+}

--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -1,0 +1,11 @@
+export default function OfflinePage() {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", minHeight: "60vh", gap: "1rem", textAlign: "center", padding: "2rem" }}>
+      <h1 style={{ fontSize: "2rem", fontWeight: "bold", color: "var(--color-text-primary)" }}>You&apos;re offline</h1>
+      <p style={{ color: "var(--color-text-secondary)", maxWidth: "400px" }}>
+        No internet connection. Cached pages are still available — check your circles or dashboard.
+      </p>
+      <a href="/" style={{ color: "var(--color-brand-primary)", textDecoration: "underline" }}>Go to home</a>
+    </div>
+  );
+}

--- a/src/components/PWAProvider.tsx
+++ b/src/components/PWAProvider.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt(): Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
+export function PWAProvider() {
+  const [installPrompt, setInstallPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+  const [showBanner, setShowBanner] = useState(false);
+
+  useEffect(() => {
+    // Register service worker
+    if ("serviceWorker" in navigator) {
+      navigator.serviceWorker.register("/sw.js").catch(() => {});
+    }
+
+    // Capture install prompt
+    const handler = (e: Event) => {
+      e.preventDefault();
+      setInstallPrompt(e as BeforeInstallPromptEvent);
+      setShowBanner(true);
+    };
+    window.addEventListener("beforeinstallprompt", handler);
+    return () => window.removeEventListener("beforeinstallprompt", handler);
+  }, []);
+
+  const handleInstall = async () => {
+    if (!installPrompt) return;
+    await installPrompt.prompt();
+    setShowBanner(false);
+    setInstallPrompt(null);
+  };
+
+  if (!showBanner) return null;
+
+  return (
+    <div style={{
+      position: "fixed", bottom: "1rem", left: "50%", transform: "translateX(-50%)",
+      background: "var(--color-bg-surface)", border: "1px solid var(--color-border)",
+      borderRadius: "var(--radius-xl)", padding: "1rem 1.5rem",
+      display: "flex", alignItems: "center", gap: "1rem",
+      boxShadow: "var(--shadow-md)", zIndex: 999, maxWidth: "calc(100vw - 2rem)",
+    }}>
+      <span style={{ fontSize: "var(--text-sm)", color: "var(--color-text-primary)" }}>
+        Add Ajosave to your home screen
+      </span>
+      <button className="btn btn--primary btn--sm" onClick={handleInstall}>Install</button>
+      <button className="btn btn--ghost btn--sm" onClick={() => setShowBanner(false)} aria-label="Dismiss">✕</button>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #69

## Changes
- **src/app/manifest.ts** — Next.js App Router manifest with `name`, `short_name`, `icons`, `theme_color` (#0f7a4a), `background_color`, `display: standalone`
- **public/sw.js** — Service worker with three caching strategies:
  - Network-first for `/api/*` (returns offline JSON on failure)
  - Cache-first for static assets (`/_next/static`, icons, images)
  - Stale-while-revalidate for page navigations with offline fallback
- **public/icons/** — SVG icons at 192×192 and 512×512
- **src/app/offline/page.tsx** — Offline fallback page served when navigation fails
- **src/components/PWAProvider.tsx** — Client component that registers the SW on mount and captures `beforeinstallprompt` to show an "Add to Home Screen" banner
- **src/app/layout.tsx** — Mounts `<PWAProvider />` in the root layout

## Acceptance Criteria
- [x] manifest.json with name, icons, theme color
- [x] Service worker caches static assets
- [x] "Add to Home Screen" prompt shown
- [x] App works offline for cached pages