### PR TITLE
Add API versioning

### DIFF
--- a/API_VERSIONING.md
+++ b/API_VERSIONING.md
@@ -1,0 +1,70 @@
+# API Versioning Implementation
+
+## Summary
+
+Added API versioning to the Ajosave project to support backward compatibility and future API evolution.
+
+## Changes Made
+
+### 1. API Structure
+- **New versioned endpoints**: All API routes moved to `/api/v1/`
+- **Backward compatibility**: Legacy `/api/` routes redirect to `/api/v1/` with deprecation headers
+- **Middleware-based redirects**: Automatic redirection handled in `src/middleware.ts`
+
+### 2. Redirect Behavior
+- **GET requests**: 301 (Moved Permanently) redirect
+- **POST/PUT/DELETE/PATCH**: 308 (Permanent Redirect) to preserve HTTP method
+- **Deprecation headers**: 
+  - `X-API-Deprecated: true`
+  - `X-API-Deprecation-Info: This endpoint is deprecated. Use /api/v1/{endpoint} instead.`
+
+### 3. Documentation Updates
+- **OpenAPI spec**: Updated to reflect v1 versioning with new base URLs
+- **API docs**: Now served at `/api/v1/docs` with updated title and spec URL
+- **Version info**: Added versioning section to API documentation
+
+### 4. Exception Handling
+- **Auth routes**: NextAuth routes (`/api/auth/`) are excluded from automatic redirection to avoid breaking authentication flow
+
+## Usage
+
+### New API Endpoints (Recommended)
+```
+GET /api/v1/circles
+POST /api/v1/circles
+GET /api/v1/health
+```
+
+### Legacy Endpoints (Deprecated)
+```
+GET /api/circles → redirects to /api/v1/circles
+POST /api/circles → redirects to /api/v1/circles  
+GET /api/health → redirects to /api/v1/health
+```
+
+## Testing
+
+To test the implementation:
+
+1. **Check v1 endpoints work**:
+   ```bash
+   curl http://localhost:3000/api/v1/health
+   ```
+
+2. **Verify redirects**:
+   ```bash
+   curl -I http://localhost:3000/api/health
+   # Should return 301 with Location: /api/v1/health
+   ```
+
+3. **Check deprecation headers**:
+   ```bash
+   curl -I http://localhost:3000/api/circles
+   # Should include X-API-Deprecated: true
+   ```
+
+## Future Considerations
+
+- When introducing breaking changes, create `/api/v2/` 
+- Consider sunset timeline for v1 deprecation
+- Monitor usage of legacy endpoints via deprecation headers

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4,10 +4,18 @@ info:
   description: |
     Trustless rotating savings circles (Ajo/Esusu) on the Stellar blockchain.
 
+    ## API Versioning
+    This API uses URL-based versioning. All endpoints are prefixed with `/api/v1/`.
+    
+    **Current version:** v1  
+    **Base URL:** `/api/v1/`
+
+    Legacy endpoints without version prefix (`/api/`) are deprecated and redirect to v1.
+
     ## Authentication
     Most endpoints require a valid session cookie obtained via the OTP login flow:
-    1. `POST /api/auth/send-otp` – request a 6-digit OTP to your phone
-    2. `POST /api/auth/verify-otp` – exchange OTP for a session cookie (NextAuth)
+    1. `POST /api/v1/auth/send-otp` – request a 6-digit OTP to your phone
+    2. `POST /api/v1/auth/verify-otp` – exchange OTP for a session cookie (NextAuth)
 
     The session cookie is automatically sent by the browser on subsequent requests.
     Server-to-server callers must include the `Cookie` header.
@@ -21,9 +29,9 @@ info:
     url: https://opensource.org/licenses/MIT
 
 servers:
-  - url: https://www.ajosave.app
+  - url: https://www.ajosave.app/api/v1
     description: Production
-  - url: http://localhost:3000
+  - url: http://localhost:3000/api/v1
     description: Local development
 
 tags:
@@ -231,7 +239,7 @@ components:
 # ─── Paths ─────────────────────────────────────────────────────────────────────
 paths:
   # ── Auth ────────────────────────────────────────────────────────────────────
-  /api/auth/send-otp:
+  /auth/send-otp:
     post:
       tags: [auth]
       summary: Request a phone OTP
@@ -276,7 +284,7 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
-  /api/auth/logout:
+  /auth/logout:
     post:
       tags: [auth]
       summary: Sign out
@@ -288,7 +296,7 @@ paths:
           description: Signed out successfully
 
   # ── Circles ─────────────────────────────────────────────────────────────────
-  /api/circles:
+  /circles:
     get:
       tags: [circles]
       summary: List circles
@@ -384,7 +392,7 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
-  /api/circles/{id}:
+  /circles/{id}:
     get:
       tags: [circles]
       summary: Get circle details
@@ -419,7 +427,7 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
-  /api/circles/{id}/join:
+  /circles/{id}/join:
     post:
       tags: [circles]
       summary: Join a circle
@@ -469,7 +477,7 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
-  /api/circles/{id}/contribute:
+  /circles/{id}/contribute:
     post:
       tags: [circles]
       summary: Initiate a contribution payment
@@ -527,7 +535,7 @@ paths:
           $ref: "#/components/responses/InternalError"
 
   # ── Cron ────────────────────────────────────────────────────────────────────
-  /api/cron/cycle:
+  /cron/cycle:
     get:
       tags: [cron]
       summary: Trigger cycle payout check
@@ -558,7 +566,7 @@ paths:
           $ref: "#/components/responses/Unauthorized"
 
   # ── Health ──────────────────────────────────────────────────────────────────
-  /api/health:
+  /health:
     get:
       tags: [health]
       summary: Health check

--- a/src/app/api/circles/route.ts
+++ b/src/app/api/circles/route.ts
@@ -1,67 +1,27 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
-import { createCircleSchema } from "@/types/schemas";
-import { createCircle, listOpenCircles, getCirclesByUser } from "@/server/services/circle.service";
-import { withErrorHandler } from "@/server/middleware";
-import type { ApiResponse, Circle } from "@/types";
-import type { PaginatedCircles } from "@/server/services/circle.service";
 
-export const GET = withErrorHandler(async (req: NextRequest) => {
-  const { searchParams } = new URL(req.url);
-  const filter = searchParams.get("filter");
-
-  if (filter === "mine") {
-    const session = await getServerSession(authOptions);
-    if (!session?.user) {
-      return NextResponse.json<ApiResponse<never>>(
-        { success: false, error: "Unauthorized" },
-        { status: 401 }
-      );
-    }
-    const userId = (session.user as { id: string }).id;
-    const circles = await getCirclesByUser(userId);
-    return NextResponse.json<ApiResponse<Circle[]>>({ success: true, data: circles });
-  }
-
-  const page = parseInt(searchParams.get("page") ?? "1", 10);
-  const limit = parseInt(searchParams.get("limit") ?? "20", 10);
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url);
+  const newUrl = url.pathname.replace('/api/circles', '/api/v1/circles');
   
-  const frequency = searchParams.get("frequency") as any;
-  const minAmount = searchParams.get("minAmount") ? parseInt(searchParams.get("minAmount")!, 10) : undefined;
-  const maxAmount = searchParams.get("maxAmount") ? parseInt(searchParams.get("maxAmount")!, 10) : undefined;
-  const currency = searchParams.get("currency") ?? undefined;
-  const search = searchParams.get("search") ?? undefined;
-
-  const result = await listOpenCircles(page, limit, {
-    frequency,
-    minAmount,
-    maxAmount,
-    currency,
-    search,
+  return NextResponse.redirect(new URL(newUrl + url.search, url.origin), {
+    status: 301,
+    headers: {
+      'X-API-Deprecated': 'true',
+      'X-API-Deprecation-Info': 'This endpoint is deprecated. Use /api/v1/circles instead.',
+    }
   });
-  return NextResponse.json<ApiResponse<PaginatedCircles>>({ success: true, data: result });
-});
+}
 
-export const POST = withErrorHandler(async (req: NextRequest) => {
-  const session = await getServerSession(authOptions);
-  if (!session?.user) {
-    return NextResponse.json<ApiResponse<never>>(
-      { success: false, error: "Unauthorized" },
-      { status: 401 }
-    );
-  }
-
-  const body = await req.json();
-  const parsed = createCircleSchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json<ApiResponse<never>>(
-      { success: false, error: parsed.error.errors[0].message },
-      { status: 400 }
-    );
-  }
-
-  const userId = (session.user as { id: string }).id;
-  const circle = await createCircle(userId, parsed.data);
-  return NextResponse.json<ApiResponse<Circle>>({ success: true, data: circle }, { status: 201 });
-});
+export async function POST(req: NextRequest) {
+  const url = new URL(req.url);
+  const newUrl = url.pathname.replace('/api/circles', '/api/v1/circles');
+  
+  return NextResponse.redirect(new URL(newUrl, url.origin), {
+    status: 308, // Preserve POST method
+    headers: {
+      'X-API-Deprecated': 'true',
+      'X-API-Deprecation-Info': 'This endpoint is deprecated. Use /api/v1/circles instead.',
+    }
+  });
+}

--- a/src/app/api/docs/route.ts
+++ b/src/app/api/docs/route.ts
@@ -1,32 +1,14 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
-const SPEC_URL = "/api/docs/spec";
-
-const html = `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Ajosave API Docs</title>
-  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css" />
-</head>
-<body>
-  <div id="swagger-ui"></div>
-  <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
-  <script>
-    SwaggerUIBundle({
-      url: "${SPEC_URL}",
-      dom_id: "#swagger-ui",
-      presets: [SwaggerUIBundle.presets.apis, SwaggerUIBundle.SwaggerUIStandalonePreset],
-      layout: "BaseLayout",
-      deepLinking: true,
-    });
-  </script>
-</body>
-</html>`;
-
-export function GET() {
-  return new NextResponse(html, {
-    headers: { "Content-Type": "text/html; charset=utf-8" },
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url);
+  const newUrl = url.pathname.replace('/api/docs', '/api/v1/docs');
+  
+  return NextResponse.redirect(new URL(newUrl + url.search, url.origin), {
+    status: 301,
+    headers: {
+      'X-API-Deprecated': 'true',
+      'X-API-Deprecation-Info': 'This endpoint is deprecated. Use /api/v1/docs instead.',
+    }
   });
 }

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,49 +1,14 @@
-import { NextResponse } from "next/server";
-import { query, getPoolStats } from "@/lib/db";
-import { serverConfig } from "@/server/config";
+import { NextRequest, NextResponse } from "next/server";
 
-async function checkDb(): Promise<boolean> {
-  try {
-    await query("SELECT 1");
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function checkRedis(): Promise<boolean> {
-  try {
-    const { createClient } = await import("redis");
-    const client = createClient({ url: serverConfig.redis.url });
-    await client.connect();
-    await client.ping();
-    await client.disconnect();
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-export async function GET() {
-  const [db, redis] = await Promise.all([checkDb(), checkRedis()]);
-
-  const healthy = db && redis;
-  const poolStats = getPoolStats();
-
-  return NextResponse.json(
-    {
-      status: healthy ? "ok" : "degraded",
-      db: db ? "ok" : "error",
-      redis: redis ? "ok" : "error",
-      pool: poolStats
-        ? {
-            total: poolStats.totalCount,
-            idle: poolStats.idleCount,
-            waiting: poolStats.waitingCount,
-          }
-        : null,
-      timestamp: new Date().toISOString(),
-    },
-    { status: healthy ? 200 : 503 }
-  );
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url);
+  const newUrl = url.pathname.replace('/api/health', '/api/v1/health');
+  
+  return NextResponse.redirect(new URL(newUrl + url.search, url.origin), {
+    status: 301,
+    headers: {
+      'X-API-Deprecated': 'true',
+      'X-API-Deprecation-Info': 'This endpoint is deprecated. Use /api/v1/health instead.',
+    }
+  });
 }

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,119 +1,27 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
-import { query } from "@/lib/db";
-import { z } from "zod";
-import type { ApiResponse } from "@/types";
 
-const updateSchema = z.object({
-  displayName: z.string().min(1).max(80).optional(),
-  email: z.string().email().optional().or(z.literal("")),
-  stellarPublicKey: z
-    .string()
-    .regex(/^G[A-Z2-7]{55}$/, "Invalid Stellar public key")
-    .optional()
-    .or(z.literal("")),
-});
-
-export type ProfileData = {
-  id: string;
-  phone: string;
-  displayName: string;
-  email: string | null;
-  stellarPublicKey: string | null;
-  reputationScore: number;
-  contributionStats: {
-    total: number;
-    confirmed: number;
-    missed: number;
-  };
-};
-
-export async function GET(): Promise<NextResponse<ApiResponse<ProfileData>>> {
-  const session = await getServerSession(authOptions);
-  if (!session?.user?.id) {
-    return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
-  }
-
-  const { rows } = await query<{
-    id: string;
-    phone: string;
-    display_name: string;
-    email: string | null;
-    stellar_public_key: string | null;
-    reputation_score: number;
-    total: string;
-    confirmed: string;
-    missed: string;
-  }>(
-    `SELECT
-       u.id, u.phone, u.display_name, u.email, u.stellar_public_key, u.reputation_score,
-       COUNT(c.id)                                          AS total,
-       COUNT(c.id) FILTER (WHERE c.status = 'confirmed')   AS confirmed,
-       COUNT(c.id) FILTER (WHERE c.status = 'missed')      AS missed
-     FROM users u
-     LEFT JOIN members m ON m.user_id = u.id
-     LEFT JOIN contributions c ON c.member_id = m.id
-     WHERE u.id = $1
-     GROUP BY u.id`,
-    [session.user.id]
-  );
-
-  if (!rows[0]) {
-    return NextResponse.json({ success: false, error: "User not found" }, { status: 404 });
-  }
-
-  const row = rows[0];
-  return NextResponse.json({
-    success: true,
-    data: {
-      id: row.id,
-      phone: row.phone,
-      displayName: row.display_name,
-      email: row.email,
-      stellarPublicKey: row.stellar_public_key,
-      reputationScore: row.reputation_score,
-      contributionStats: {
-        total: Number(row.total),
-        confirmed: Number(row.confirmed),
-        missed: Number(row.missed),
-      },
-    },
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url);
+  const newUrl = url.pathname.replace('/api/profile', '/api/v1/profile');
+  
+  return NextResponse.redirect(new URL(newUrl + url.search, url.origin), {
+    status: 301,
+    headers: {
+      'X-API-Deprecated': 'true',
+      'X-API-Deprecation-Info': 'This endpoint is deprecated. Use /api/v1/profile instead.',
+    }
   });
 }
 
-export async function PATCH(
-  req: NextRequest
-): Promise<NextResponse<ApiResponse<{ updated: true }>>> {
-  const session = await getServerSession(authOptions);
-  if (!session?.user?.id) {
-    return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
-  }
-
-  const body = await req.json();
-  const parsed = updateSchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json(
-      { success: false, error: parsed.error.errors[0].message },
-      { status: 400 }
-    );
-  }
-
-  const { displayName, email, stellarPublicKey } = parsed.data;
-
-  await query(
-    `UPDATE users
-     SET display_name        = COALESCE($1, display_name),
-         email               = COALESCE($2, email),
-         stellar_public_key  = COALESCE($3, stellar_public_key)
-     WHERE id = $4`,
-    [
-      displayName ?? null,
-      email !== undefined ? (email === "" ? null : email) : null,
-      stellarPublicKey !== undefined ? (stellarPublicKey === "" ? null : stellarPublicKey) : null,
-      session.user.id,
-    ]
-  );
-
-  return NextResponse.json({ success: true, data: { updated: true } });
+export async function PUT(req: NextRequest) {
+  const url = new URL(req.url);
+  const newUrl = url.pathname.replace('/api/profile', '/api/v1/profile');
+  
+  return NextResponse.redirect(new URL(newUrl, url.origin), {
+    status: 308, // Preserve PUT method
+    headers: {
+      'X-API-Deprecated': 'true',
+      'X-API-Deprecation-Info': 'This endpoint is deprecated. Use /api/v1/profile instead.',
+    }
+  });
 }

--- a/src/app/api/v1/admin/circles/[id]/payout/route.ts
+++ b/src/app/api/v1/admin/circles/[id]/payout/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getCircleById, getMembersByCircle } from "@/server/services/circle.service";
+import { processCyclePayout, PayoutLockError } from "@/server/services/payout.service";
+import { withAdminAuth, withErrorHandler } from "@/server/middleware";
+import type { ApiResponse, Payout } from "@/types";
+
+/**
+ * POST /api/admin/circles/[id]/payout
+ * Manually trigger a payout cycle for a circle (admin only).
+ * Requires the circle to be active and the next recipient to have a Stellar key.
+ */
+export const POST = withErrorHandler(
+  withAdminAuth(async (_req: NextRequest, ctx: unknown) => {
+    const { params } = ctx as { params: { id: string } };
+
+    const circle = await getCircleById(params.id);
+    if (!circle) {
+      return NextResponse.json<ApiResponse<never>>(
+        { success: false, error: "Circle not found" },
+        { status: 404 }
+      );
+    }
+    if (circle.status !== "active") {
+      return NextResponse.json<ApiResponse<never>>(
+        { success: false, error: "Circle is not active" },
+        { status: 400 }
+      );
+    }
+
+    const members = await getMembersByCircle(params.id);
+    const recipient = members.find((m) => m.position === circle.currentCycle);
+    if (!recipient) {
+      return NextResponse.json<ApiResponse<never>>(
+        { success: false, error: "No recipient found for current cycle" },
+        { status: 400 }
+      );
+    }
+
+    try {
+      // recipientStellarKey is resolved inside processCyclePayout via the contract path,
+      // or passed here for the Horizon fallback. We pass empty string for contract circles.
+      const payout = await processCyclePayout(params.id, "");
+      return NextResponse.json<ApiResponse<Payout>>({ success: true, data: payout });
+    } catch (err) {
+      if (err instanceof PayoutLockError) {
+        return NextResponse.json<ApiResponse<never>>(
+          { success: false, error: "Payout already in progress for this circle" },
+          { status: 409 }
+        );
+      }
+      throw err;
+    }
+  })
+);

--- a/src/app/api/v1/admin/circles/route.ts
+++ b/src/app/api/v1/admin/circles/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { adminListCircles } from "@/server/services/admin.service";
+import { withAdminAuth, withErrorHandler } from "@/server/middleware";
+import type { ApiResponse } from "@/types";
+import type { AdminCircleRow } from "@/server/services/admin.service";
+
+export const GET = withErrorHandler(
+  withAdminAuth(async () => {
+    const circles = await adminListCircles();
+    return NextResponse.json<ApiResponse<AdminCircleRow[]>>({ success: true, data: circles });
+  })
+);

--- a/src/app/api/v1/admin/horizon-stream/route.ts
+++ b/src/app/api/v1/admin/horizon-stream/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import {
+  startHorizonStream,
+  stopHorizonStream,
+  getStreamStatus,
+} from "@/server/services/horizon-stream.service";
+import { withErrorHandler } from "@/server/middleware";
+import type { ApiResponse } from "@/types";
+
+/**
+ * GET /api/admin/horizon-stream
+ * Get Horizon stream status
+ */
+export const GET = withErrorHandler(async (_req: NextRequest) => {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  // TODO: Add admin role check
+  // if (session.user.role !== 'admin') {
+  //   return NextResponse.json<ApiResponse<never>>(
+  //     { success: false, error: "Forbidden" },
+  //     { status: 403 }
+  //   );
+  // }
+
+  const status = getStreamStatus();
+
+  return NextResponse.json<ApiResponse<{ running: boolean }>>({
+    success: true,
+    data: status,
+  });
+});
+
+/**
+ * POST /api/admin/horizon-stream
+ * Start or stop the Horizon stream
+ */
+export const POST = withErrorHandler(async (req: NextRequest) => {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  // TODO: Add admin role check
+
+  const body = await req.json();
+  const { action } = body as { action: "start" | "stop" };
+
+  if (action === "start") {
+    await startHorizonStream();
+    return NextResponse.json<ApiResponse<{ message: string }>>({
+      success: true,
+      data: { message: "Horizon stream started" },
+    });
+  } else if (action === "stop") {
+    stopHorizonStream();
+    return NextResponse.json<ApiResponse<{ message: string }>>({
+      success: true,
+      data: { message: "Horizon stream stopped" },
+    });
+  } else {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Invalid action. Use 'start' or 'stop'" },
+      { status: 400 }
+    );
+  }
+});

--- a/src/app/api/v1/admin/payouts/route.ts
+++ b/src/app/api/v1/admin/payouts/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { adminListPayouts } from "@/server/services/admin.service";
+import { withAdminAuth, withErrorHandler } from "@/server/middleware";
+import type { ApiResponse } from "@/types";
+import type { AdminPayoutRow } from "@/server/services/admin.service";
+
+export const GET = withErrorHandler(
+  withAdminAuth(async () => {
+    const payouts = await adminListPayouts();
+    return NextResponse.json<ApiResponse<AdminPayoutRow[]>>({ success: true, data: payouts });
+  })
+);

--- a/src/app/api/v1/auth/[...nextauth]/route.ts
+++ b/src/app/api/v1/auth/[...nextauth]/route.ts
@@ -1,0 +1,4 @@
+import NextAuth from "next-auth";
+import { authOptions } from "@/lib/auth";
+const handler = NextAuth(authOptions);
+export { handler as GET, handler as POST };

--- a/src/app/api/v1/auth/logout/route.ts
+++ b/src/app/api/v1/auth/logout/route.ts
@@ -1,0 +1,19 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { NextResponse } from "next/server";
+
+/**
+ * POST /api/auth/logout
+ * Invalidates the session server-side (clears the JWT cookie via NextAuth signOut).
+ * TODO: when Redis is wired up, also add the refresh token to a denylist here.
+ */
+export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  // TODO: redis.set(`revoked:${token.id}`, 1, { EX: REFRESH_TOKEN_TTL })
+  // The client must call next-auth signOut() to clear the cookie.
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/v1/auth/send-otp/route.ts
+++ b/src/app/api/v1/auth/send-otp/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sendOtp } from "@/lib/sms";
+import { rateLimit, withErrorHandler } from "@/server/middleware";
+import { sendOtpSchema } from "@/types/schemas";
+import type { ApiResponse } from "@/types";
+import { getRedis } from "@/lib/redis";
+import { isLockedOut } from "@/lib/lockout";
+
+export const POST = withErrorHandler(async (req: NextRequest) => {
+  const body = await req.json();
+  const parsed = sendOtpSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: parsed.error.errors[0].message },
+      { status: 400 }
+    );
+  }
+
+  const { phone } = parsed.data;
+
+  // Check for account lockout (brute-force protection)
+  if (await isLockedOut(phone)) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Account locked due to too many failed attempts. Please try again in 30 minutes." },
+      { status: 423 }
+    );
+  }
+
+  const rl = await rateLimit(`otp:${phone}`, 3, 10 * 60 * 1000);
+  if (!rl.allowed) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Too many requests. Please wait before requesting another OTP." },
+      { status: 429 }
+    );
+  }
+
+  const otp = await sendOtp(phone);
+  
+  // Store OTP in Redis with 10-minute expiry
+  const redis = await getRedis();
+  await redis.set(`otp:${phone}`, otp, { EX: 600 });
+
+  if (process.env.NODE_ENV === "development") console.warn(`[DEV] OTP for ${phone}: ${otp}`);
+  
+  return NextResponse.json<ApiResponse<{ message: string }>>({
+    success: true,
+    data: { message: "OTP sent successfully" },
+  });
+});

--- a/src/app/api/v1/circles/[id]/cancel/route.ts
+++ b/src/app/api/v1/circles/[id]/cancel/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { cancelCircle } from "@/server/services/circle.service";
+import { withErrorHandler } from "@/server/middleware";
+import type { ApiResponse, Circle } from "@/types";
+
+export const POST = withErrorHandler(async (_req: NextRequest, ctx: unknown) => {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  const { params } = ctx as { params: { id: string } };
+  const userId = (session.user as { id: string }).id;
+
+  try {
+    const circle = await cancelCircle(params.id, userId);
+    return NextResponse.json<ApiResponse<Circle>>({ success: true, data: circle });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to cancel circle";
+    const status =
+      message === "Circle not found" ? 404 :
+      message === "Only the creator can cancel a circle" ? 403 : 400;
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: message },
+      { status }
+    );
+  }
+});

--- a/src/app/api/v1/circles/[id]/contribute/__tests__/route.test.ts
+++ b/src/app/api/v1/circles/[id]/contribute/__tests__/route.test.ts
@@ -1,0 +1,129 @@
+/**
+ * @jest-environment node
+ */
+import { POST } from "@/app/api/circles/[id]/contribute/route";
+import { NextRequest } from "next/server";
+
+jest.mock("next-auth", () => ({ getServerSession: jest.fn() }));
+jest.mock("@/lib/auth", () => ({ authOptions: {} }));
+jest.mock("@/server/services/circle.service");
+jest.mock("@/lib/paystack");
+jest.mock("@/lib/db");
+jest.mock("@/server/config", () => ({
+  serverConfig: {
+    app: { url: "http://localhost:3000" },
+    paystack: { secretKey: "test" },
+    stellar: { network: "testnet", sorobanRpcUrl: "http://localhost", ajoContractId: "test" },
+  },
+}));
+jest.mock("@/server/middleware", () => ({
+  withErrorHandler: (fn: Function) => fn,
+}));
+
+import { getServerSession } from "next-auth";
+import { getCircleById, getMembersByCircle } from "@/server/services/circle.service";
+import { initializePayment } from "@/lib/paystack";
+import * as db from "@/lib/db";
+
+const mockSession = getServerSession as jest.MockedFunction<typeof getServerSession>;
+const mockGetCircle = getCircleById as jest.MockedFunction<typeof getCircleById>;
+const mockGetMembers = getMembersByCircle as jest.MockedFunction<typeof getMembersByCircle>;
+const mockInitPayment = initializePayment as jest.MockedFunction<typeof initializePayment>;
+const mockQuery = db.query as jest.MockedFunction<typeof db.query>;
+
+const CIRCLE_ID = "circle-1";
+const MEMBER_ID = "member-1";
+const USER_ID = "user-1";
+const CYCLE = 2;
+
+const circle = {
+  id: CIRCLE_ID,
+  status: "active",
+  currentCycle: CYCLE,
+  contributionFiat: 5000,
+  contributionCurrency: "NGN",
+  contributionUsdc: "3.0000000",
+} as any;
+
+const member = { id: MEMBER_ID, userId: USER_ID } as any;
+
+function makeRequest() {
+  return new NextRequest(`http://localhost/api/circles/${CIRCLE_ID}/contribute`, { method: "POST" });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSession.mockResolvedValue({ user: { id: USER_ID, email: "user@test.com" } } as any);
+  mockGetCircle.mockResolvedValue(circle);
+  mockGetMembers.mockResolvedValue([member]);
+});
+
+describe("POST /api/circles/[id]/contribute", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockSession.mockResolvedValue(null);
+    const res = await POST(makeRequest(), { params: { id: CIRCLE_ID } });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when circle not found", async () => {
+    mockGetCircle.mockResolvedValue(null);
+    const res = await POST(makeRequest(), { params: { id: CIRCLE_ID } });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when circle is not active", async () => {
+    mockGetCircle.mockResolvedValue({ ...circle, status: "open" } as any);
+    const res = await POST(makeRequest(), { params: { id: CIRCLE_ID } });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 403 when user is not a member", async () => {
+    mockGetMembers.mockResolvedValue([]);
+    const res = await POST(makeRequest(), { params: { id: CIRCLE_ID } });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns existing authorizationUrl on duplicate (idempotent)", async () => {
+    const existingUrl = "https://paystack.com/pay/existing";
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ paystack_reference: `ajo-${CIRCLE_ID}-${MEMBER_ID}-${CYCLE}`, authorization_url: existingUrl }],
+      rowCount: 1,
+    } as any);
+
+    const res = await POST(makeRequest(), { params: { id: CIRCLE_ID } });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data.authorizationUrl).toBe(existingUrl);
+    expect(json.data.reference).toBe(`ajo-${CIRCLE_ID}-${MEMBER_ID}-${CYCLE}`);
+    expect(mockInitPayment).not.toHaveBeenCalled();
+  });
+
+  it("initializes payment and upserts contribution for new request", async () => {
+    const authUrl = "https://paystack.com/pay/new";
+    // No existing pending contribution
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 } as any);
+    // Upsert insert
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 } as any);
+    mockInitPayment.mockResolvedValue({ authorizationUrl: authUrl, reference: `ajo-${CIRCLE_ID}-${MEMBER_ID}-${CYCLE}` });
+
+    const res = await POST(makeRequest(), { params: { id: CIRCLE_ID } });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data.authorizationUrl).toBe(authUrl);
+    expect(json.data.reference).toBe(`ajo-${CIRCLE_ID}-${MEMBER_ID}-${CYCLE}`);
+
+    expect(mockInitPayment).toHaveBeenCalledWith(
+      expect.objectContaining({ reference: `ajo-${CIRCLE_ID}-${MEMBER_ID}-${CYCLE}` })
+    );
+    // Upsert query
+    expect(mockQuery).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("ON CONFLICT (member_id, cycle_number)"),
+      expect.arrayContaining([`ajo-${CIRCLE_ID}-${MEMBER_ID}-${CYCLE}`, authUrl])
+    );
+  });
+});

--- a/src/app/api/v1/circles/[id]/contribute/route.ts
+++ b/src/app/api/v1/circles/[id]/contribute/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getCircleById, getMembersByCircle } from "@/server/services/circle.service";
+import { initializePayment } from "@/lib/paystack";
+import { serverConfig } from "@/server/config";
+import { withErrorHandler } from "@/server/middleware";
+import { query } from "@/lib/db";
+import { randomUUID } from "crypto";
+import type { ApiResponse } from "@/types";
+
+export const POST = withErrorHandler(async (_req: NextRequest, ctx: unknown) => {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  const { params } = ctx as { params: { id: string } };
+  const circle = await getCircleById(params.id);
+  if (!circle) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Circle not found" },
+      { status: 404 }
+    );
+  }
+  if (circle.status !== "active") {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Circle is not active" },
+      { status: 400 }
+    );
+  }
+
+  const circleMembers = await getMembersByCircle(params.id);
+  const userId = (session.user as { id: string; email?: string }).id;
+  const member = circleMembers.find((m) => m.userId === userId);
+  if (!member) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "You are not a member of this circle" },
+      { status: 403 }
+    );
+  }
+
+  // Deterministic reference: ajo-{circleId}-{memberId}-{cycleNumber}
+  const reference = `ajo-${params.id}-${member.id}-${circle.currentCycle}`;
+
+  // Return existing authorizationUrl if a pending contribution already exists for this cycle
+  const { rows: existing } = await query<{ paystack_reference: string; authorization_url: string }>(
+    `SELECT paystack_reference, authorization_url
+     FROM contributions
+     WHERE member_id = $1 AND cycle_number = $2 AND status = 'pending'
+     LIMIT 1`,
+    [member.id, circle.currentCycle]
+  );
+  if (existing.length > 0 && existing[0].authorization_url) {
+    return NextResponse.json<ApiResponse<{ authorizationUrl: string; reference: string }>>({
+      success: true,
+      data: { authorizationUrl: existing[0].authorization_url, reference: existing[0].paystack_reference },
+    });
+  }
+
+  const callbackUrl = `${serverConfig.app.url}/circles/${params.id}/contribute/callback?reference=${reference}`;
+
+  const { authorizationUrl } = await initializePayment({
+    email: (session.user as { email?: string }).email ?? `${userId}@ajosave.app`,
+    amount: circle.contributionFiat,
+    currency: circle.contributionCurrency,
+    reference,
+    callbackUrl,
+    metadata: {
+      circleId: params.id,
+      memberId: member.id,
+      cycleNumber: circle.currentCycle,
+    },
+  });
+
+  // Upsert pending contribution with paystack_reference and authorization_url
+  await query(
+    `INSERT INTO contributions (id, circle_id, member_id, cycle_number, amount_usdc, status, paystack_reference, authorization_url)
+     VALUES ($1, $2, $3, $4, $5, 'pending', $6, $7)
+     ON CONFLICT (member_id, cycle_number) DO UPDATE
+       SET paystack_reference = EXCLUDED.paystack_reference,
+           authorization_url  = EXCLUDED.authorization_url`,
+    [randomUUID(), params.id, member.id, circle.currentCycle, circle.contributionUsdc, reference, authorizationUrl]
+  );
+
+  return NextResponse.json<ApiResponse<{ authorizationUrl: string; reference: string }>>({
+    success: true,
+    data: { authorizationUrl, reference },
+  });
+});

--- a/src/app/api/v1/circles/[id]/contribute/verify/__tests__/route.test.ts
+++ b/src/app/api/v1/circles/[id]/contribute/verify/__tests__/route.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from "@/app/api/circles/[id]/contribute/verify/route";
+import { NextRequest } from "next/server";
+
+jest.mock("next-auth", () => ({ getServerSession: jest.fn() }));
+jest.mock("@/lib/auth", () => ({ authOptions: {} }));
+jest.mock("@/lib/paystack");
+jest.mock("@/server/services/circle.service");
+jest.mock("@/server/services/notification.service");
+jest.mock("@/server/middleware", () => ({
+  withErrorHandler: (fn: Function) => fn,
+}));
+jest.mock("@/server/config", () => ({
+  serverConfig: { paystack: { secretKey: "test" }, stellar: { network: "testnet", sorobanRpcUrl: "http://localhost", ajoContractId: "test" } },
+}));
+
+import { getServerSession } from "next-auth";
+import { verifyPayment } from "@/lib/paystack";
+import { getCircleById } from "@/server/services/circle.service";
+import { notifyContributionReceived } from "@/server/services/notification.service";
+
+const mockSession = getServerSession as jest.MockedFunction<typeof getServerSession>;
+const mockVerify = verifyPayment as jest.MockedFunction<typeof verifyPayment>;
+const mockGetCircle = getCircleById as jest.MockedFunction<typeof getCircleById>;
+const mockNotify = notifyContributionReceived as jest.MockedFunction<typeof notifyContributionReceived>;
+
+function makeRequest(params: Record<string, string>) {
+  const url = new URL("http://localhost/api/circles/c1/contribute/verify");
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  return new NextRequest(url);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockNotify.mockResolvedValue(undefined as any);
+});
+
+describe("GET /api/circles/[id]/contribute/verify", () => {
+  it("returns 400 when reference is missing", async () => {
+    const res = await GET(makeRequest({}));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.success).toBe(false);
+  });
+
+  it("returns verified payment data for a successful payment", async () => {
+    mockVerify.mockResolvedValue({ status: "success", amount: 500000, currency: "NGN" });
+    mockSession.mockResolvedValue({ user: { id: "user-1" } } as any);
+    mockGetCircle.mockResolvedValue({ name: "Test Circle", contributionUsdc: "3.0" } as any);
+
+    const res = await GET(makeRequest({ reference: "ajo-c1-m1-2", circleId: "c1", cycleNumber: "2" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data.status).toBe("success");
+    expect(json.data.amount).toBe(500000);
+  });
+
+  it("sends notification on successful payment", async () => {
+    mockVerify.mockResolvedValue({ status: "success", amount: 500000, currency: "NGN" });
+    mockSession.mockResolvedValue({ user: { id: "user-1" } } as any);
+    mockGetCircle.mockResolvedValue({ name: "Test Circle", contributionUsdc: "3.0" } as any);
+
+    await GET(makeRequest({ reference: "ajo-c1-m1-2", circleId: "c1", cycleNumber: "2" }));
+
+    // Allow async notification to fire
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockNotify).toHaveBeenCalledWith("user-1", "Test Circle", "3.0", 2);
+  });
+
+  it("returns failed status without sending notification", async () => {
+    mockVerify.mockResolvedValue({ status: "failed", amount: 500000, currency: "NGN" });
+    mockSession.mockResolvedValue({ user: { id: "user-1" } } as any);
+
+    const res = await GET(makeRequest({ reference: "ref-failed", circleId: "c1", cycleNumber: "2" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.data.status).toBe("failed");
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it("returns pending status", async () => {
+    mockVerify.mockResolvedValue({ status: "pending", amount: 0, currency: "NGN" });
+
+    const res = await GET(makeRequest({ reference: "ref-pending" }));
+    const json = await res.json();
+
+    expect(json.data.status).toBe("pending");
+  });
+
+  it("propagates Paystack API errors via error handler", async () => {
+    mockVerify.mockRejectedValue(new Error("Paystack down"));
+    await expect(GET(makeRequest({ reference: "ref-x" }))).rejects.toThrow("Paystack down");
+  });
+});

--- a/src/app/api/v1/circles/[id]/contribute/verify/route.ts
+++ b/src/app/api/v1/circles/[id]/contribute/verify/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyPayment } from "@/lib/paystack";
+import { withErrorHandler } from "@/server/middleware";
+import { notifyContributionReceived } from "@/server/services/notification.service";
+import { getCircleById } from "@/server/services/circle.service";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import type { ApiResponse } from "@/types";
+
+export const GET = withErrorHandler(async (req: NextRequest) => {
+  const reference = req.nextUrl.searchParams.get("reference");
+  if (!reference) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Missing reference" },
+      { status: 400 }
+    );
+  }
+
+  const result = await verifyPayment(reference);
+  
+  // Send SMS confirmation if payment was successful
+  if (result.status === "success") {
+    const session = await getServerSession(authOptions);
+    const circleId = req.nextUrl.searchParams.get("circleId");
+    const cycleNumber = req.nextUrl.searchParams.get("cycleNumber");
+    
+    if (session?.user?.id && circleId && cycleNumber) {
+      const circle = await getCircleById(circleId);
+      if (circle) {
+        // Send notification (async, don't block)
+        notifyContributionReceived(
+          session.user.id,
+          circle.name,
+          circle.contributionUsdc,
+          parseInt(cycleNumber)
+        ).catch(err => {
+          console.error("Failed to send contribution confirmation:", err);
+        });
+      }
+    }
+  }
+  
+  return NextResponse.json<ApiResponse<typeof result>>({ success: true, data: result });
+});

--- a/src/app/api/v1/circles/[id]/invite/route.ts
+++ b/src/app/api/v1/circles/[id]/invite/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getCircleById } from "@/server/services/circle.service";
+import { createInviteToken } from "@/lib/tokens";
+import { withErrorHandler } from "@/server/middleware";
+import { serverConfig } from "@/server/config";
+import type { ApiResponse } from "@/types";
+
+export const GET = withErrorHandler(async (req: NextRequest, ctx: unknown) => {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  const { params } = ctx as { params: { id: string } };
+  const circle = await getCircleById(params.id);
+  
+  if (!circle) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Circle not found" },
+      { status: 404 }
+    );
+  }
+
+  const userId = (session.user as { id: string }).id;
+  if (circle.creatorId !== userId) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Only the circle creator can generate invite links" },
+      { status: 403 }
+    );
+  }
+
+  const token = await createInviteToken(circle.id);
+  const inviteUrl = `${serverConfig.app.url}/circles/${circle.id}/join?token=${token}`;
+
+  return NextResponse.json<ApiResponse<{ inviteUrl: string }>>({
+    success: true,
+    data: { inviteUrl },
+  });
+});

--- a/src/app/api/v1/circles/[id]/join/__tests__/route.test.ts
+++ b/src/app/api/v1/circles/[id]/join/__tests__/route.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @jest-environment node
+ */
+import { POST } from "@/app/api/circles/[id]/join/route";
+import { NextRequest } from "next/server";
+import { getServerSession } from "next-auth";
+import { getCircleById, joinCircle } from "@/server/services/circle.service";
+import { verifyInviteToken } from "@/lib/tokens";
+
+jest.mock("next-auth", () => ({ getServerSession: jest.fn() }));
+jest.mock("@/lib/auth", () => ({ authOptions: {} }));
+jest.mock("@/server/services/circle.service");
+jest.mock("@/lib/tokens");
+jest.mock("@/server/middleware", () => ({
+  withErrorHandler: (fn: Function) => fn,
+}));
+
+const mockSession = getServerSession as jest.MockedFunction<typeof getServerSession>;
+const mockGetCircle = getCircleById as jest.MockedFunction<typeof getCircleById>;
+const mockJoinCircle = joinCircle as jest.MockedFunction<typeof joinCircle>;
+const mockVerifyToken = verifyInviteToken as jest.MockedFunction<typeof verifyInviteToken>;
+
+const USER_ID = "user-1";
+const CIRCLE_ID = "circle-1";
+
+describe("POST /api/circles/[id]/join", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const makeRequest = (body: any = {}) => {
+    return new NextRequest(`http://localhost/api/circles/${CIRCLE_ID}/join`, {
+      method: "POST",
+      body: JSON.stringify({
+        stellarPublicKey: "GDZ74K6L3R5S6N4X3P6Q5W4E3R2T1Y0U9I8O7P6A5S4D3F2G1H0J9K8L",
+        ...body,
+      }),
+    });
+  };
+
+  it("joins a public circle successfully", async () => {
+    mockSession.mockResolvedValue({ user: { id: USER_ID } } as any);
+    mockGetCircle.mockResolvedValue({ id: CIRCLE_ID, circleType: "public" } as any);
+    const mockMember = { id: "member-1", circleId: CIRCLE_ID, userId: USER_ID };
+    mockJoinCircle.mockResolvedValue(mockMember as any);
+
+    const res = await POST(makeRequest(), { params: { id: CIRCLE_ID } });
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.success).toBe(true);
+    expect(json.data).toEqual(mockMember);
+    expect(mockJoinCircle).toHaveBeenCalledWith(CIRCLE_ID, USER_ID, false);
+  });
+
+  it("joins a private circle successfully with valid token", async () => {
+    const token = "valid-token";
+    mockSession.mockResolvedValue({ user: { id: USER_ID } } as any);
+    mockGetCircle.mockResolvedValue({ id: CIRCLE_ID, circleType: "private" } as any);
+    mockVerifyToken.mockResolvedValue({ circleId: CIRCLE_ID } as any);
+    const mockMember = { id: "member-1", circleId: CIRCLE_ID, userId: USER_ID };
+    mockJoinCircle.mockResolvedValue(mockMember as any);
+
+    const res = await POST(makeRequest({ token }), { params: { id: CIRCLE_ID } });
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.success).toBe(true);
+    expect(mockJoinCircle).toHaveBeenCalledWith(CIRCLE_ID, USER_ID, true);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockSession.mockResolvedValue(null);
+    const res = await POST(makeRequest(), { params: { id: CIRCLE_ID } });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when circle not found", async () => {
+    mockSession.mockResolvedValue({ user: { id: USER_ID } } as any);
+    mockGetCircle.mockResolvedValue(null);
+    const res = await POST(makeRequest(), { params: { id: CIRCLE_ID } });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when joining private circle without token", async () => {
+    mockSession.mockResolvedValue({ user: { id: USER_ID } } as any);
+    mockGetCircle.mockResolvedValue({ id: CIRCLE_ID, circleType: "private" } as any);
+    const res = await POST(makeRequest(), { params: { id: CIRCLE_ID } });
+    const json = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(json.error).toContain("Invite token is required");
+  });
+
+  it("returns 403 with invalid token for private circle", async () => {
+    const token = "invalid-token";
+    mockSession.mockResolvedValue({ user: { id: USER_ID } } as any);
+    mockGetCircle.mockResolvedValue({ id: CIRCLE_ID, circleType: "private" } as any);
+    mockVerifyToken.mockResolvedValue(null);
+
+    const res = await POST(makeRequest({ token }), { params: { id: CIRCLE_ID } });
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/app/api/v1/circles/[id]/join/route.ts
+++ b/src/app/api/v1/circles/[id]/join/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { joinCircleSchema } from "@/types/schemas";
+import { joinCircle, getCircleById } from "@/server/services/circle.service";
+import { withErrorHandler } from "@/server/middleware";
+import { verifyInviteToken } from "@/lib/tokens";
+import type { ApiResponse, Member } from "@/types";
+
+export const POST = withErrorHandler(async (req: NextRequest, ctx: unknown) => {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  const { params } = ctx as { params: { id: string } };
+  const body = await req.json();
+  const parsed = joinCircleSchema.safeParse({ ...body, circleId: params.id });
+  if (!parsed.success) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: parsed.error.errors[0].message },
+      { status: 400 }
+    );
+  }
+
+  const { token } = parsed.data;
+  const circle = await getCircleById(params.id);
+  if (!circle) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Circle not found" },
+      { status: 404 }
+    );
+  }
+
+  let isInvited = false;
+  if (circle.circleType === "private") {
+    if (!token) {
+      return NextResponse.json<ApiResponse<never>>(
+        { success: false, error: "Invite token is required for private circles" },
+        { status: 403 }
+      );
+    }
+    const decoded = await verifyInviteToken(token);
+    if (!decoded || decoded.circleId !== params.id) {
+      return NextResponse.json<ApiResponse<never>>(
+        { success: false, error: "Invalid or expired invite token" },
+        { status: 403 }
+      );
+    }
+    isInvited = true;
+  } else if (token) {
+    // Also check token for public circles if provided
+    const decoded = await verifyInviteToken(token);
+    if (decoded && decoded.circleId === params.id) {
+      isInvited = true;
+    }
+  }
+
+  const userId = (session.user as { id: string }).id;
+  const member = await joinCircle(params.id, userId, isInvited);
+  return NextResponse.json<ApiResponse<Member>>({ success: true, data: member }, { status: 201 });
+});

--- a/src/app/api/v1/circles/[id]/leave/route.ts
+++ b/src/app/api/v1/circles/[id]/leave/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { leaveCircle } from "@/server/services/circle.service";
+import { withErrorHandler } from "@/server/middleware";
+
+export const POST = withErrorHandler(
+  async (req: NextRequest, { params }: { params: { id: string } }) => {
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+    }
+
+    const circleId = params.id;
+    await leaveCircle(circleId, session.user.id);
+
+    return NextResponse.json({
+      success: true,
+      message: "Successfully left the circle",
+    });
+  }
+);

--- a/src/app/api/v1/circles/[id]/members/[memberId]/approve/route.ts
+++ b/src/app/api/v1/circles/[id]/members/[memberId]/approve/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { approveJoinRequest } from "@/server/services/circle.service";
+import { sendSms } from "@/lib/sms";
+import type { ApiResponse, Member } from "@/types";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string; memberId: string } }
+): Promise<NextResponse<ApiResponse<Member>>> {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { success: false, error: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    const { id: circleId, memberId } = params;
+    const member = await approveJoinRequest(circleId, memberId, session.user.id);
+
+    // TODO: Send SMS notification to approved user
+    // await sendSms(member.userId, "Your join request has been approved!");
+
+    return NextResponse.json({ success: true, data: member });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to approve join request";
+    return NextResponse.json(
+      { success: false, error: message },
+      { status: 400 }
+    );
+  }
+}

--- a/src/app/api/v1/circles/[id]/members/[memberId]/reject/route.ts
+++ b/src/app/api/v1/circles/[id]/members/[memberId]/reject/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { rejectJoinRequest } from "@/server/services/circle.service";
+import { sendSms } from "@/lib/sms";
+import type { ApiResponse, Member } from "@/types";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string; memberId: string } }
+): Promise<NextResponse<ApiResponse<Member>>> {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { success: false, error: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    const { id: circleId, memberId } = params;
+    const member = await rejectJoinRequest(circleId, memberId, session.user.id);
+
+    // TODO: Send SMS notification to rejected user
+    // await sendSms(member.userId, "Your join request has been declined.");
+
+    return NextResponse.json({ success: true, data: member });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to reject join request";
+    return NextResponse.json(
+      { success: false, error: message },
+      { status: 400 }
+    );
+  }
+}

--- a/src/app/api/v1/circles/[id]/pending-requests/route.ts
+++ b/src/app/api/v1/circles/[id]/pending-requests/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getPendingJoinRequests, getCircleById } from "@/server/services/circle.service";
+import type { ApiResponse, Member } from "@/types";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+): Promise<NextResponse<ApiResponse<Member[]>>> {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { success: false, error: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    const circleId = params.id;
+    const circle = await getCircleById(circleId);
+    
+    if (!circle) {
+      return NextResponse.json(
+        { success: false, error: "Circle not found" },
+        { status: 404 }
+      );
+    }
+
+    // Only circle creator can view pending requests
+    if (circle.creatorId !== session.user.id) {
+      return NextResponse.json(
+        { success: false, error: "Only the circle creator can view pending requests" },
+        { status: 403 }
+      );
+    }
+
+    const pendingRequests = await getPendingJoinRequests(circleId);
+    return NextResponse.json({ success: true, data: pendingRequests });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to fetch pending requests";
+    return NextResponse.json(
+      { success: false, error: message },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/v1/circles/[id]/route.ts
+++ b/src/app/api/v1/circles/[id]/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getCircleById, getMembersByCircle } from "@/server/services/circle.service";
+import { withErrorHandler } from "@/server/middleware";
+import type { ApiResponse, Circle, Member } from "@/types";
+
+export const GET = withErrorHandler(async (_req: NextRequest, ctx: unknown) => {
+  const { params } = ctx as { params: { id: string } };
+  const circle = await getCircleById(params.id);
+  if (!circle) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Circle not found" },
+      { status: 404 }
+    );
+  }
+  const circleMembers = await getMembersByCircle(params.id);
+  return NextResponse.json<ApiResponse<{ circle: Circle; members: Member[] }>>({
+    success: true,
+    data: { circle, members: circleMembers },
+  });
+});

--- a/src/app/api/v1/circles/[id]/shuffle/route.ts
+++ b/src/app/api/v1/circles/[id]/shuffle/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getCircleById, shuffleAndPersistPositions } from "@/server/services/circle.service";
+import { withErrorHandler } from "@/server/middleware";
+import type { ApiResponse, Member } from "@/types";
+import { randomBytes } from "crypto";
+
+/**
+ * POST /api/circles/[id]/shuffle
+ * Randomizes payout positions for an open circle (creator only).
+ * Generates a seed, persists shuffled positions to DB, and stores seed for verifiability.
+ */
+export const POST = withErrorHandler(async (_req: NextRequest, ctx: unknown) => {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  const { params } = ctx as { params: { id: string } };
+  const circle = await getCircleById(params.id);
+  if (!circle) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Circle not found" },
+      { status: 404 }
+    );
+  }
+
+  const userId = (session.user as { id: string }).id;
+  if (circle.creatorId !== userId) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Only the circle creator can shuffle positions" },
+      { status: 403 }
+    );
+  }
+
+  if (circle.status !== "open") {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Positions can only be shuffled before the circle starts" },
+      { status: 400 }
+    );
+  }
+
+  // Generate deterministic seed from current timestamp and random bytes
+  const seed = `${Date.now()}-${randomBytes(16).toString("hex")}`;
+
+  try {
+    const shuffled = await shuffleAndPersistPositions(params.id, seed);
+    return NextResponse.json<ApiResponse<Member[]>>({ success: true, data: shuffled });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to shuffle positions";
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: message },
+      { status: 400 }
+    );
+  }
+});

--- a/src/app/api/v1/circles/[id]/sync-payout-order/route.ts
+++ b/src/app/api/v1/circles/[id]/sync-payout-order/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getCircleById, getMembersByCircle } from "@/server/services/circle.service";
+import { withErrorHandler } from "@/server/middleware";
+import { invokeContractSetPayoutOrder } from "@/lib/soroban";
+import type { ApiResponse } from "@/types";
+
+/**
+ * POST /api/circles/[id]/sync-payout-order
+ * Syncs randomized payout order from DB to smart contract (admin/creator only).
+ * Must be called after shuffle and before circle starts.
+ */
+export const POST = withErrorHandler(async (_req: NextRequest, ctx: unknown) => {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  const { params } = ctx as { params: { id: string } };
+  const circle = await getCircleById(params.id);
+  if (!circle) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Circle not found" },
+      { status: 404 }
+    );
+  }
+
+  const userId = (session.user as { id: string }).id;
+  if (circle.creatorId !== userId) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Only the circle creator can sync payout order" },
+      { status: 403 }
+    );
+  }
+
+  if (circle.status !== "open") {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Payout order can only be synced before the circle starts" },
+      { status: 400 }
+    );
+  }
+
+  if (circle.payoutMethod !== "randomized") {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Circle is not using randomized payout method" },
+      { status: 400 }
+    );
+  }
+
+  if (!circle.contractId) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Circle does not have a deployed smart contract" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const members = await getMembersByCircle(params.id);
+    
+    // Build payout order: map member positions to their indices in the members array
+    // Members are sorted by position, so we need to find the original join order
+    const membersByJoinOrder = [...members].sort((a, b) => 
+      new Date(a.joinedAt).getTime() - new Date(b.joinedAt).getTime()
+    );
+    
+    const payoutOrder = members.map((m) => {
+      const joinIndex = membersByJoinOrder.findIndex((jm) => jm.id === m.id);
+      return joinIndex;
+    });
+
+    // Sync to smart contract
+    await invokeContractSetPayoutOrder(circle.contractId, payoutOrder);
+
+    return NextResponse.json<ApiResponse<{ payoutOrder: number[] }>>(
+      { success: true, data: { payoutOrder } }
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to sync payout order";
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: message },
+      { status: 400 }
+    );
+  }
+});

--- a/src/app/api/v1/circles/__tests__/route.test.ts
+++ b/src/app/api/v1/circles/__tests__/route.test.ts
@@ -1,0 +1,129 @@
+/**
+ * @jest-environment node
+ */
+import { GET, POST } from "@/app/api/circles/route";
+import { NextRequest } from "next/server";
+import { getServerSession } from "next-auth";
+import { createCircle, listOpenCircles, getCirclesByUser } from "@/server/services/circle.service";
+
+jest.mock("next-auth", () => ({ getServerSession: jest.fn() }));
+jest.mock("@/lib/auth", () => ({ authOptions: {} }));
+jest.mock("@/server/services/circle.service");
+jest.mock("@/server/middleware", () => ({
+  withErrorHandler: (fn: Function) => fn,
+}));
+
+const mockSession = getServerSession as jest.MockedFunction<typeof getServerSession>;
+const mockCreateCircle = createCircle as jest.MockedFunction<typeof createCircle>;
+const mockListOpenCircles = listOpenCircles as jest.MockedFunction<typeof listOpenCircles>;
+const mockGetCirclesByUser = getCirclesByUser as jest.MockedFunction<typeof getCirclesByUser>;
+
+const USER_ID = "user-1";
+
+describe("Circles API Routes", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("GET /api/circles", () => {
+    it("returns open circles with pagination", async () => {
+      const mockResult = {
+        data: [{ id: "1", name: "Circle 1" }],
+        total: 1,
+        page: 1,
+        limit: 10,
+      };
+      mockListOpenCircles.mockResolvedValue(mockResult as any);
+
+      const req = new NextRequest("http://localhost/api/circles?page=1&limit=10");
+      const res = await GET(req);
+      const json = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(json.success).toBe(true);
+      expect(json.data).toEqual(mockResult);
+      expect(mockListOpenCircles).toHaveBeenCalledWith(1, 10, expect.any(Object));
+    });
+
+    it("returns user's circles when filter=mine is provided", async () => {
+      mockSession.mockResolvedValue({ user: { id: USER_ID } } as any);
+      const mockCircles = [{ id: "1", name: "My Circle" }];
+      mockGetCirclesByUser.mockResolvedValue(mockCircles as any);
+
+      const req = new NextRequest("http://localhost/api/circles?filter=mine");
+      const res = await GET(req);
+      const json = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(json.success).toBe(true);
+      expect(json.data).toEqual(mockCircles);
+      expect(mockGetCirclesByUser).toHaveBeenCalledWith(USER_ID);
+    });
+
+    it("returns 401 for filter=mine when unauthenticated", async () => {
+      mockSession.mockResolvedValue(null);
+
+      const req = new NextRequest("http://localhost/api/circles?filter=mine");
+      const res = await GET(req);
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("POST /api/circles", () => {
+    const validBody = {
+      name: "Test Circle",
+      contributionAmount: 5000,
+      contributionCurrency: "NGN",
+      maxMembers: 10,
+      cycleFrequency: "monthly",
+      payoutMethod: "fixed",
+    };
+
+    it("creates a new circle when authenticated and valid data", async () => {
+      mockSession.mockResolvedValue({ user: { id: USER_ID } } as any);
+      const mockCircle = { id: "new-circle", ...validBody };
+      mockCreateCircle.mockResolvedValue(mockCircle as any);
+
+      const req = new NextRequest("http://localhost/api/circles", {
+        method: "POST",
+        body: JSON.stringify(validBody),
+      });
+      const res = await POST(req);
+      const json = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(json.success).toBe(true);
+      expect(json.data).toEqual(mockCircle);
+      expect(mockCreateCircle).toHaveBeenCalledWith(USER_ID, expect.objectContaining({ name: "Test Circle" }));
+    });
+
+    it("returns 401 when unauthenticated", async () => {
+      mockSession.mockResolvedValue(null);
+
+      const req = new NextRequest("http://localhost/api/circles", {
+        method: "POST",
+        body: JSON.stringify(validBody),
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 400 when validation fails", async () => {
+      mockSession.mockResolvedValue({ user: { id: USER_ID } } as any);
+      const invalidBody = { ...validBody, name: "" }; // Name too short
+
+      const req = new NextRequest("http://localhost/api/circles", {
+        method: "POST",
+        body: JSON.stringify(invalidBody),
+      });
+      const res = await POST(req);
+      const json = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(json.success).toBe(false);
+      expect(json.error).toBeDefined();
+    });
+  });
+});

--- a/src/app/api/v1/circles/route.ts
+++ b/src/app/api/v1/circles/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { createCircleSchema } from "@/types/schemas";
+import { createCircle, listOpenCircles, getCirclesByUser } from "@/server/services/circle.service";
+import { withErrorHandler } from "@/server/middleware";
+import type { ApiResponse, Circle } from "@/types";
+import type { PaginatedCircles } from "@/server/services/circle.service";
+
+export const GET = withErrorHandler(async (req: NextRequest) => {
+  const { searchParams } = new URL(req.url);
+  const filter = searchParams.get("filter");
+
+  if (filter === "mine") {
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json<ApiResponse<never>>(
+        { success: false, error: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+    const userId = (session.user as { id: string }).id;
+    const circles = await getCirclesByUser(userId);
+    return NextResponse.json<ApiResponse<Circle[]>>({ success: true, data: circles });
+  }
+
+  const page = parseInt(searchParams.get("page") ?? "1", 10);
+  const limit = parseInt(searchParams.get("limit") ?? "20", 10);
+  
+  const frequency = searchParams.get("frequency") as any;
+  const minAmount = searchParams.get("minAmount") ? parseInt(searchParams.get("minAmount")!, 10) : undefined;
+  const maxAmount = searchParams.get("maxAmount") ? parseInt(searchParams.get("maxAmount")!, 10) : undefined;
+  const currency = searchParams.get("currency") ?? undefined;
+  const search = searchParams.get("search") ?? undefined;
+
+  const result = await listOpenCircles(page, limit, {
+    frequency,
+    minAmount,
+    maxAmount,
+    currency,
+    search,
+  });
+  return NextResponse.json<ApiResponse<PaginatedCircles>>({ success: true, data: result });
+});
+
+export const POST = withErrorHandler(async (req: NextRequest) => {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  const body = await req.json();
+  const parsed = createCircleSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: parsed.error.errors[0].message },
+      { status: 400 }
+    );
+  }
+
+  const userId = (session.user as { id: string }).id;
+  const circle = await createCircle(userId, parsed.data);
+  return NextResponse.json<ApiResponse<Circle>>({ success: true, data: circle }, { status: 201 });
+});

--- a/src/app/api/v1/cron/cycle/__tests__/route.test.ts
+++ b/src/app/api/v1/cron/cycle/__tests__/route.test.ts
@@ -1,0 +1,84 @@
+import { GET } from "../route";
+import { NextRequest } from "next/server";
+import * as schedulerService from "@/server/services/scheduler.service";
+import { serverConfig } from "@/server/config";
+
+jest.mock("@/server/services/scheduler.service");
+
+const mockProcessDueCycles = schedulerService.processDueCycles as jest.MockedFunction<
+  typeof schedulerService.processDueCycles
+>;
+
+// Cast to allow mutation in tests
+const mutableConfig = serverConfig as { cronSecret: string };
+
+function makeRequest(authHeader?: string): NextRequest {
+  const headers: Record<string, string> = {};
+  if (authHeader !== undefined) {
+    headers["authorization"] = authHeader;
+  }
+  return new NextRequest("http://localhost/api/cron/cycle", { headers });
+}
+
+describe("GET /api/cron/cycle", () => {
+  const VALID_SECRET = "test-cron-secret-xyz";
+  const originalSecret = serverConfig.cronSecret;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mutableConfig.cronSecret = VALID_SECRET;
+    mockProcessDueCycles.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    mutableConfig.cronSecret = originalSecret;
+  });
+
+  it("processes due cycles when authenticated with valid secret", async () => {
+    const req = makeRequest(`Bearer ${VALID_SECRET}`);
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      success: true,
+      data: { message: "Cycle check complete" },
+    });
+    expect(mockProcessDueCycles).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 401 when Authorization header is missing", async () => {
+    const req = makeRequest();
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toEqual({ success: false, error: "Unauthorized" });
+    expect(mockProcessDueCycles).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when token is incorrect", async () => {
+    const req = makeRequest("Bearer wrong-token");
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    expect(mockProcessDueCycles).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when CRON_SECRET is not configured", async () => {
+    mutableConfig.cronSecret = "";
+    const req = makeRequest("Bearer anything");
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    expect(mockProcessDueCycles).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when Authorization header has no Bearer prefix", async () => {
+    const req = makeRequest(VALID_SECRET); // missing "Bearer "
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    expect(mockProcessDueCycles).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/v1/cron/cycle/route.ts
+++ b/src/app/api/v1/cron/cycle/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from "next/server";
+import { processDueCycles } from "@/server/services/scheduler.service";
+import { verifyCronSecret } from "@/lib/cron-auth";
+import type { ApiResponse } from "@/types";
+
+export const GET = async (req: NextRequest) => {
+  const unauth = verifyCronSecret(req);
+  if (unauth) return unauth;
+
+  await processDueCycles();
+  return NextResponse.json<ApiResponse<{ message: string }>>({
+    success: true,
+    data: { message: "Cycle check complete" },
+  });
+};

--- a/src/app/api/v1/cron/missed-contributions/route.ts
+++ b/src/app/api/v1/cron/missed-contributions/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { processMissedContributions } from "@/server/services/scheduler.service";
+import { verifyCronSecret } from "@/lib/cron-auth";
+
+/**
+ * Cron endpoint to process missed contributions
+ * Should be called daily by a cron service (Vercel Cron, GitHub Actions, etc.)
+ * 
+ * Authorization: Bearer <CRON_SECRET>
+ */
+export async function GET(req: NextRequest) {
+  const unauth = verifyCronSecret(req);
+  if (unauth) return unauth;
+
+  try {
+    await processMissedContributions();
+
+    return NextResponse.json({
+      success: true,
+      message: "Missed contributions processed successfully",
+    });
+  } catch (error) {
+    console.error("Failed to process missed contributions:", error);
+    return NextResponse.json(
+      { 
+        success: false, 
+        error: error instanceof Error ? error.message : "Failed to process missed contributions" 
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/v1/cron/reminders/route.ts
+++ b/src/app/api/v1/cron/reminders/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sendPayoutReminders } from "@/server/services/scheduler.service";
+import { verifyCronSecret } from "@/lib/cron-auth";
+
+/**
+ * Cron endpoint to send payout reminders
+ * Should be called hourly by a cron service (Vercel Cron, GitHub Actions, etc.)
+ * 
+ * Authorization: Bearer <CRON_SECRET>
+ */
+export async function GET(req: NextRequest) {
+  const unauth = verifyCronSecret(req);
+  if (unauth) return unauth;
+
+  try {
+    await sendPayoutReminders();
+
+    return NextResponse.json({
+      success: true,
+      message: "Payout reminders sent successfully",
+    });
+  } catch (error) {
+    console.error("Failed to send payout reminders:", error);
+    return NextResponse.json(
+      { 
+        success: false, 
+        error: error instanceof Error ? error.message : "Failed to send reminders" 
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/v1/docs/route.ts
+++ b/src/app/api/v1/docs/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+
+const SPEC_URL = "/api/v1/docs/spec";
+
+const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Ajosave API v1 Docs</title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css" />
+</head>
+<body>
+  <div id="swagger-ui"></div>
+  <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+  <script>
+    SwaggerUIBundle({
+      url: "${SPEC_URL}",
+      dom_id: "#swagger-ui",
+      presets: [SwaggerUIBundle.presets.apis, SwaggerUIBundle.SwaggerUIStandalonePreset],
+      layout: "BaseLayout",
+      deepLinking: true,
+    });
+  </script>
+</body>
+</html>`;
+
+export function GET() {
+  return new NextResponse(html, {
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}

--- a/src/app/api/v1/docs/spec/route.ts
+++ b/src/app/api/v1/docs/spec/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+export function GET() {
+  const spec = readFileSync(join(process.cwd(), "docs/openapi.yaml"), "utf-8");
+  return new NextResponse(spec, {
+    headers: { "Content-Type": "application/yaml; charset=utf-8" },
+  });
+}

--- a/src/app/api/v1/fx/rate/route.ts
+++ b/src/app/api/v1/fx/rate/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse, NextRequest } from "next/server";
+import { getFiatPerUsdc } from "@/lib/fx";
+import type { ApiResponse } from "@/types";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const currency = req.nextUrl.searchParams.get("currency") || "NGN";
+  
+  try {
+    const rate = await getFiatPerUsdc(currency);
+    return NextResponse.json<ApiResponse<{ rate: number; currency: string; fetchedAt: string }>>({
+      success: true,
+      data: { rate, currency, fetchedAt: new Date().toISOString() },
+    });
+  } catch (err) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: `Failed to fetch FX rate for ${currency}` },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/v1/health/route.ts
+++ b/src/app/api/v1/health/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { query, getPoolStats } from "@/lib/db";
+import { serverConfig } from "@/server/config";
+
+async function checkDb(): Promise<boolean> {
+  try {
+    await query("SELECT 1");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function checkRedis(): Promise<boolean> {
+  try {
+    const { createClient } = await import("redis");
+    const client = createClient({ url: serverConfig.redis.url });
+    await client.connect();
+    await client.ping();
+    await client.disconnect();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function GET() {
+  const [db, redis] = await Promise.all([checkDb(), checkRedis()]);
+
+  const healthy = db && redis;
+  const poolStats = getPoolStats();
+
+  return NextResponse.json(
+    {
+      status: healthy ? "ok" : "degraded",
+      db: db ? "ok" : "error",
+      redis: redis ? "ok" : "error",
+      pool: poolStats
+        ? {
+            total: poolStats.totalCount,
+            idle: poolStats.idleCount,
+            waiting: poolStats.waitingCount,
+          }
+        : null,
+      timestamp: new Date().toISOString(),
+    },
+    { status: healthy ? 200 : 503 }
+  );
+}

--- a/src/app/api/v1/profile/route.ts
+++ b/src/app/api/v1/profile/route.ts
@@ -1,0 +1,119 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { query } from "@/lib/db";
+import { z } from "zod";
+import type { ApiResponse } from "@/types";
+
+const updateSchema = z.object({
+  displayName: z.string().min(1).max(80).optional(),
+  email: z.string().email().optional().or(z.literal("")),
+  stellarPublicKey: z
+    .string()
+    .regex(/^G[A-Z2-7]{55}$/, "Invalid Stellar public key")
+    .optional()
+    .or(z.literal("")),
+});
+
+export type ProfileData = {
+  id: string;
+  phone: string;
+  displayName: string;
+  email: string | null;
+  stellarPublicKey: string | null;
+  reputationScore: number;
+  contributionStats: {
+    total: number;
+    confirmed: number;
+    missed: number;
+  };
+};
+
+export async function GET(): Promise<NextResponse<ApiResponse<ProfileData>>> {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { rows } = await query<{
+    id: string;
+    phone: string;
+    display_name: string;
+    email: string | null;
+    stellar_public_key: string | null;
+    reputation_score: number;
+    total: string;
+    confirmed: string;
+    missed: string;
+  }>(
+    `SELECT
+       u.id, u.phone, u.display_name, u.email, u.stellar_public_key, u.reputation_score,
+       COUNT(c.id)                                          AS total,
+       COUNT(c.id) FILTER (WHERE c.status = 'confirmed')   AS confirmed,
+       COUNT(c.id) FILTER (WHERE c.status = 'missed')      AS missed
+     FROM users u
+     LEFT JOIN members m ON m.user_id = u.id
+     LEFT JOIN contributions c ON c.member_id = m.id
+     WHERE u.id = $1
+     GROUP BY u.id`,
+    [session.user.id]
+  );
+
+  if (!rows[0]) {
+    return NextResponse.json({ success: false, error: "User not found" }, { status: 404 });
+  }
+
+  const row = rows[0];
+  return NextResponse.json({
+    success: true,
+    data: {
+      id: row.id,
+      phone: row.phone,
+      displayName: row.display_name,
+      email: row.email,
+      stellarPublicKey: row.stellar_public_key,
+      reputationScore: row.reputation_score,
+      contributionStats: {
+        total: Number(row.total),
+        confirmed: Number(row.confirmed),
+        missed: Number(row.missed),
+      },
+    },
+  });
+}
+
+export async function PATCH(
+  req: NextRequest
+): Promise<NextResponse<ApiResponse<{ updated: true }>>> {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const parsed = updateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, error: parsed.error.errors[0].message },
+      { status: 400 }
+    );
+  }
+
+  const { displayName, email, stellarPublicKey } = parsed.data;
+
+  await query(
+    `UPDATE users
+     SET display_name        = COALESCE($1, display_name),
+         email               = COALESCE($2, email),
+         stellar_public_key  = COALESCE($3, stellar_public_key)
+     WHERE id = $4`,
+    [
+      displayName ?? null,
+      email !== undefined ? (email === "" ? null : email) : null,
+      stellarPublicKey !== undefined ? (stellarPublicKey === "" ? null : stellarPublicKey) : null,
+      session.user.id,
+    ]
+  );
+
+  return NextResponse.json({ success: true, data: { updated: true } });
+}

--- a/src/app/api/v1/user/sms-preferences/route.ts
+++ b/src/app/api/v1/user/sms-preferences/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { toggleSmsNotifications } from "@/server/services/notification.service";
+import { smsPreferencesSchema } from "@/types/schemas";
+import type { ApiResponse } from "@/types";
+
+export async function POST(req: NextRequest): Promise<NextResponse<ApiResponse<{ enabled: boolean }>>> {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { success: false, error: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    const body = await req.json();
+    const parsed = smsPreferencesSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { success: false, error: parsed.error.errors[0].message },
+        { status: 400 }
+      );
+    }
+
+    const { enabled } = parsed.data;
+    await toggleSmsNotifications(session.user.id, enabled);
+
+    return NextResponse.json({ 
+      success: true, 
+      data: { enabled } 
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to update SMS preferences";
+    return NextResponse.json(
+      { success: false, error: message },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/v1/users/[id]/reputation/route.ts
+++ b/src/app/api/v1/users/[id]/reputation/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getReputationStats, verifyReputation } from "@/lib/reputation";
+import { query } from "@/lib/db";
+import { withErrorHandler } from "@/server/middleware";
+import type { ApiResponse } from "@/types";
+
+/**
+ * GET /api/users/[id]/reputation
+ * Fetch on-chain reputation for a user
+ */
+export const GET = withErrorHandler(async (_req: NextRequest, ctx: unknown) => {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  const { params } = ctx as { params: { id: string } };
+  const { searchParams } = new URL(_req.url);
+  const verify = searchParams.get("verify") === "true";
+
+  // Fetch user's Stellar address
+  const { rows } = await query<{ stellar_public_key: string | null }>(
+    "SELECT stellar_public_key FROM users WHERE id = $1",
+    [params.id]
+  );
+
+  if (rows.length === 0) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "User not found" },
+      { status: 404 }
+    );
+  }
+
+  const stellarAddress = rows[0].stellar_public_key;
+  if (!stellarAddress) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "User has no Stellar address" },
+      { status: 400 }
+    );
+  }
+
+  // Fetch on-chain reputation stats
+  const stats = await getReputationStats(stellarAddress);
+
+  // Optionally verify against database
+  let isVerified: boolean | undefined;
+  if (verify) {
+    isVerified = await verifyReputation(params.id, stellarAddress);
+  }
+
+  return NextResponse.json<
+    ApiResponse<{
+      score: number;
+      circlesCompleted: number;
+      onTimeContributions: number;
+      totalContributions: number;
+      isVerified?: boolean;
+    }>
+  >({
+    success: true,
+    data: {
+      ...stats,
+      ...(verify && { isVerified }),
+    },
+  });
+});

--- a/src/app/api/v1/webhooks/paystack/__tests__/route.test.ts
+++ b/src/app/api/v1/webhooks/paystack/__tests__/route.test.ts
@@ -1,0 +1,94 @@
+/**
+ * @jest-environment node
+ */
+import { POST } from "@/app/api/webhooks/paystack/route";
+import { NextRequest } from "next/server";
+import { createHmac } from "crypto";
+
+jest.mock("@/lib/db");
+jest.mock("@/server/config", () => ({
+  serverConfig: { paystack: { secretKey: "test-secret" } },
+}));
+
+import * as db from "@/lib/db";
+const mockQuery = db.query as jest.MockedFunction<typeof db.query>;
+
+const SECRET = "test-secret";
+
+function makeRequest(body: object, signature?: string): NextRequest {
+  const raw = JSON.stringify(body);
+  const sig =
+    signature ??
+    createHmac("sha512", SECRET).update(raw).digest("hex");
+  return new NextRequest("http://localhost/api/webhooks/paystack", {
+    method: "POST",
+    headers: { "x-paystack-signature": sig, "content-type": "application/json" },
+    body: raw,
+  });
+}
+
+const CHARGE_SUCCESS = {
+  event: "charge.success",
+  data: { reference: "ajo-circle-1-member-1-2" },
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("POST /api/webhooks/paystack", () => {
+  it("returns 401 for invalid signature", async () => {
+    const req = makeRequest(CHARGE_SUCCESS, "badsignature");
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 200 and skips non-charge.success events", async () => {
+    const req = makeRequest({ event: "transfer.success", data: {} });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.received).toBe(true);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when reference is missing", async () => {
+    const req = makeRequest({ event: "charge.success", data: {} });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("confirms contribution on charge.success using paystack_reference", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 } as any)
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 } as any);
+
+    const req = makeRequest(CHARGE_SUCCESS);
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.received).toBe(true);
+
+    // Idempotency check uses paystack_reference
+    expect(mockQuery).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining("paystack_reference = $1"),
+      ["ajo-circle-1-member-1-2"]
+    );
+    // Confirm update uses paystack_reference
+    expect(mockQuery).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("paystack_reference = $1"),
+      ["ajo-circle-1-member-1-2"]
+    );
+  });
+
+  it("returns duplicate:true and skips update for already-processed reference", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: "contrib-1" }], rowCount: 1 } as any);
+
+    const req = makeRequest(CHARGE_SUCCESS);
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.duplicate).toBe(true);
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/api/v1/webhooks/paystack/route.ts
+++ b/src/app/api/v1/webhooks/paystack/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createHmac, timingSafeEqual } from "crypto";
+import { query } from "@/lib/db";
+import { serverConfig } from "@/server/config";
+
+function verifySignature(payload: string, signature: string): boolean {
+  const expected = createHmac("sha512", serverConfig.paystack.secretKey)
+    .update(payload)
+    .digest("hex");
+  try {
+    return timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
+  } catch {
+    return false;
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const signature = req.headers.get("x-paystack-signature") ?? "";
+  const rawBody = await req.text();
+
+  if (!verifySignature(rawBody, signature)) {
+    return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+  }
+
+  const event = JSON.parse(rawBody);
+
+  if (event.event !== "charge.success") {
+    return NextResponse.json({ received: true });
+  }
+
+  const reference: string = event.data?.reference;
+  if (!reference) {
+    return NextResponse.json({ error: "Missing reference" }, { status: 400 });
+  }
+
+  // Idempotency: skip if already confirmed
+  const { rows } = await query<{ id: string }>(
+    `SELECT id FROM contributions WHERE paystack_reference = $1 AND status = 'confirmed' LIMIT 1`,
+    [reference]
+  );
+  if (rows.length > 0) {
+    return NextResponse.json({ received: true, duplicate: true });
+  }
+
+  // Confirm the pending contribution matching this paystack_reference
+  await query(
+    `UPDATE contributions
+     SET status = 'confirmed', tx_hash = $1
+     WHERE paystack_reference = $1 AND status = 'pending'`,
+    [reference]
+  );
+
+  return NextResponse.json({ received: true });
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -13,6 +13,24 @@ const ALLOWED_ORIGINS = [
 export function middleware(request: NextRequest) {
   const origin = request.headers.get("origin");
 
+  // Handle API versioning redirects
+  if (request.nextUrl.pathname.startsWith("/api/") && !request.nextUrl.pathname.startsWith("/api/v1/")) {
+    // Skip auth routes as they need special handling
+    if (!request.nextUrl.pathname.startsWith("/api/auth/")) {
+      const newUrl = request.nextUrl.clone();
+      newUrl.pathname = newUrl.pathname.replace('/api/', '/api/v1/');
+      
+      const response = NextResponse.redirect(newUrl, {
+        status: request.method === 'GET' ? 301 : 308,
+      });
+      
+      response.headers.set('X-API-Deprecated', 'true');
+      response.headers.set('X-API-Deprecation-Info', `This endpoint is deprecated. Use ${newUrl.pathname} instead.`);
+      
+      return response;
+    }
+  }
+
   // Handle CORS for API routes
   if (request.nextUrl.pathname.startsWith("/api/")) {
     const isAllowed = origin && ALLOWED_ORIGINS.includes(origin);


### PR DESCRIPTION
- Move all routes to /api/v1/ structure
- Add middleware redirects for backward compatibility
- Include deprecation headers on legacy endpoints
- Update OpenAPI spec for v1 versioning
- Document API versioning implementation

Fixes #42

