### PR TITLE
Feat/contribution reminders circle chat

### DIFF
--- a/.kiro/specs/circle-chat/.config.kiro
+++ b/.kiro/specs/circle-chat/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "6f502639-a32f-4049-8dbc-5b8b97545719", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/circle-chat/design.md
+++ b/.kiro/specs/circle-chat/design.md
@@ -1,0 +1,589 @@
+# Design Document: Circle Chat
+
+## Overview
+
+Circle Chat adds a persistent, real-time message thread to each savings circle. Members can coordinate payout timing, share updates, and communicate without leaving the app. The feature is scoped to active members only and integrates with the existing Socket.io WebSocket infrastructure, Next.js API route pattern, and React Query client-side data fetching.
+
+The design follows the established patterns in the codebase:
+- **Service layer**: parameterized SQL queries with camelCase column aliases (matching `circle.service.ts`)
+- **API routes**: `withErrorHandler` + `withRateLimit` middleware, `getServerSession` auth, `ApiResponse<T>` shape (matching `contribute/route.ts`)
+- **WebSocket**: `broadcastX()` functions emitting to `circle:{id}` rooms (matching `websocket.ts`)
+- **Hook**: `socket.on(event, handler)` in `useEffect` with cleanup (matching `useRealtimeUpdates.ts`)
+- **Components**: CSS Modules, TypeScript props, React Query for data fetching (matching `CircleCard.tsx`)
+
+### Key Design Decisions
+
+1. **Cursor-based pagination over offset**: Using `before` (ISO timestamp) as a cursor avoids the "page drift" problem where new messages shift offset-based pages. The query `WHERE created_at < $before ORDER BY created_at ASC LIMIT $limit` is stable and index-friendly.
+
+2. **WebSocket broadcast on POST success**: The API route calls `broadcastChatMessage()` after the DB insert succeeds. The sender's own UI also receives the event via the socket subscription, so the optimistic-update pattern is not needed — the message appears via the real-time path for all clients including the sender.
+
+3. **Author `display_name` joined at query time**: Rather than storing `display_name` in `circle_messages`, the service JOINs `users` on every read. This keeps the data normalized and ensures display name changes are reflected immediately.
+
+4. **Rate limiting on POST only**: The `withRateLimit` wrapper (30 req/min per IP) is applied only to POST. GET requests are read-only and already protected by the active-member check.
+
+5. **Content validation at API layer**: The API validates `content` length (1–1000 chars) before hitting the DB. The DB constraint is a safety net, not the primary enforcement point.
+
+---
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant Client as Browser (CircleChat)
+    participant API as /api/circles/[id]/chat
+    participant Service as chat.service.ts
+    participant DB as PostgreSQL
+    participant WS as websocket.ts (Socket.io)
+
+    Note over Client,WS: POST a message
+    Client->>API: POST { content }
+    API->>API: getServerSession → 401 if no session
+    API->>DB: SELECT member status → 403 if not active
+    API->>API: Validate content (1–1000 chars) → 400 if invalid
+    API->>Service: postMessage(circleId, userId, content)
+    Service->>DB: INSERT INTO circle_messages
+    DB-->>Service: { id, circleId, userId, content, createdAt }
+    Service->>DB: SELECT display_name FROM users WHERE id = userId
+    Service-->>API: CircleMessage (with displayName)
+    API->>WS: broadcastChatMessage(circleId, message)
+    WS->>Client: socket emit "chat:message" → circle:{id} room
+    API-->>Client: 201 { success: true, data: CircleMessage }
+
+    Note over Client,WS: Load message history
+    Client->>API: GET ?limit=50&before=<ISO>
+    API->>API: getServerSession → 401 if no session
+    API->>DB: SELECT member status → 403 if not active
+    API->>Service: getMessages(circleId, { limit, before })
+    Service->>DB: SELECT ... WHERE circle_id=$1 AND created_at < $before ORDER BY created_at ASC LIMIT $limit
+    DB-->>Service: CircleMessage[]
+    Service-->>API: CircleMessage[]
+    API-->>Client: 200 { success: true, data: CircleMessage[] }
+```
+
+### Component Interaction Diagram
+
+```mermaid
+graph TD
+    A[CircleDetailPage<br/>src/app/circles/id/page.tsx] -->|renders if active member| B[CircleChat<br/>src/components/circle/CircleChat.tsx]
+    B -->|useQuery| C[GET /api/circles/id/chat]
+    B -->|useMutation| D[POST /api/circles/id/chat]
+    B -->|useRealtimeUpdates onChatMessage| E[useRealtimeUpdates hook]
+    E -->|socket.on chat:message| F[Socket.io client]
+    F <-->|WebSocket| G[Socket.io server<br/>websocket.ts]
+    C --> H[chat.service.ts getMessages]
+    D --> I[chat.service.ts postMessage]
+    I --> G
+    H --> J[(circle_messages table)]
+    I --> J
+```
+
+---
+
+## Components and Interfaces
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `migrations/<timestamp>_add-circle-messages-table.ts` | Creates `circle_messages` table with index |
+| `src/server/services/chat.service.ts` | `postMessage()`, `getMessages()` — DB access layer |
+| `src/app/api/circles/[id]/chat/route.ts` | GET + POST handlers |
+| `src/components/circle/CircleChat.tsx` | Client component: message list + input |
+| `src/components/circle/CircleChat.module.css` | Scoped styles for CircleChat |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `src/types/index.ts` | Add `CircleMessage` type |
+| `src/server/websocket.ts` | Add `chat:message` to `WebSocketEvents`; add `broadcastChatMessage()` |
+| `src/hooks/useRealtimeUpdates.ts` | Add `onChatMessage` option |
+| `src/app/circles/[id]/page.tsx` | Render `<CircleChat>` for active members |
+
+### `CircleMessage` Type
+
+```typescript
+// src/types/index.ts
+export interface CircleMessage {
+  id: string;
+  circleId: string;
+  userId: string;
+  displayName: string;   // joined from users table at read time
+  content: string;
+  createdAt: string;     // ISO 8601 string
+}
+```
+
+### `WebSocketEvents` Addition
+
+```typescript
+// src/server/websocket.ts
+export interface WebSocketEvents {
+  // ... existing events ...
+  "chat:message": {
+    id: string;
+    circleId: string;
+    userId: string;
+    displayName: string;
+    content: string;
+    createdAt: string;
+  };
+}
+```
+
+### `broadcastChatMessage()` Function
+
+```typescript
+export function broadcastChatMessage(
+  circleId: string,
+  message: WebSocketEvents["chat:message"]
+): void {
+  if (!io) return;
+  io.to(`circle:${circleId}`).emit("chat:message", message);
+  console.log(`[websocket] Broadcasted chat:message to circle:${circleId}`);
+}
+```
+
+### `useRealtimeUpdates` Hook Addition
+
+```typescript
+interface UseRealtimeUpdatesOptions {
+  // ... existing options ...
+  onChatMessage?: (data: WebSocketEvents["chat:message"]) => void;
+}
+// Inside useEffect:
+if (onChatMessage) {
+  socket.on("chat:message", onChatMessage);
+}
+```
+
+### Chat Service Interface
+
+```typescript
+// src/server/services/chat.service.ts
+
+export interface GetMessagesOptions {
+  limit?: number;   // 1–100, default 50
+  before?: string;  // ISO 8601 timestamp cursor
+}
+
+export async function postMessage(
+  circleId: string,
+  userId: string,
+  content: string
+): Promise<CircleMessage>
+
+export async function getMessages(
+  circleId: string,
+  options?: GetMessagesOptions
+): Promise<CircleMessage[]>
+```
+
+### API Route Interface
+
+```
+GET  /api/circles/[id]/chat?limit=50&before=<ISO>
+  → 200 ApiResponse<CircleMessage[]>
+  → 401 if no session
+  → 403 if not active member
+
+POST /api/circles/[id]/chat
+  Body: { content: string }
+  → 201 ApiResponse<CircleMessage>
+  → 400 if content missing/empty/too long
+  → 401 if no session
+  → 403 if not active member
+  → 429 if rate limited (30 req/min per IP)
+```
+
+### `CircleChat` Component Props
+
+```typescript
+interface CircleChatProps {
+  circleId: string;
+  isActiveMember: boolean;
+  currentUserId: string;
+}
+```
+
+---
+
+## Data Models
+
+### `circle_messages` Table
+
+```sql
+CREATE TABLE circle_messages (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  circle_id   UUID        NOT NULL REFERENCES circles(id) ON DELETE CASCADE,
+  user_id     VARCHAR(255) NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  content     TEXT        NOT NULL
+                CHECK (char_length(content) >= 1 AND char_length(content) <= 1000),
+  created_at  TIMESTAMP   NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_circle_messages_circle_created
+  ON circle_messages (circle_id, created_at);
+```
+
+### Migration File
+
+Timestamp: `1746200000000` (next in sequence after `1746100000000`)
+
+```typescript
+// migrations/1746200000000_add-circle-messages-table.ts
+import { MigrationBuilder } from "node-pg-migrate";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createTable("circle_messages", {
+    id: { type: "uuid", primaryKey: true, default: pgm.func("gen_random_uuid()") },
+    circle_id: {
+      type: "uuid",
+      notNull: true,
+      references: "circles(id)",
+      onDelete: "CASCADE",
+    },
+    user_id: {
+      type: "varchar(255)",
+      notNull: true,
+      references: "users(id)",
+      onDelete: "CASCADE",
+    },
+    content: {
+      type: "text",
+      notNull: true,
+      check: "char_length(content) >= 1 AND char_length(content) <= 1000",
+    },
+    created_at: {
+      type: "timestamp",
+      notNull: true,
+      default: pgm.func("NOW()"),
+    },
+  });
+
+  pgm.createIndex("circle_messages", ["circle_id", "created_at"], {
+    name: "idx_circle_messages_circle_created",
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropTable("circle_messages");
+}
+```
+
+### Chat Service SQL Queries
+
+**`postMessage`** — insert and return with display_name:
+```sql
+INSERT INTO circle_messages (circle_id, user_id, content)
+VALUES ($1, $2, $3)
+RETURNING
+  id,
+  circle_id   AS "circleId",
+  user_id     AS "userId",
+  content,
+  created_at  AS "createdAt"
+```
+Followed by a JOIN to fetch `display_name`:
+```sql
+SELECT
+  cm.id,
+  cm.circle_id   AS "circleId",
+  cm.user_id     AS "userId",
+  u.display_name AS "displayName",
+  cm.content,
+  cm.created_at  AS "createdAt"
+FROM circle_messages cm
+JOIN users u ON u.id = cm.user_id
+WHERE cm.id = $1
+```
+
+**`getMessages`** — cursor-based pagination:
+```sql
+SELECT
+  cm.id,
+  cm.circle_id   AS "circleId",
+  cm.user_id     AS "userId",
+  u.display_name AS "displayName",
+  cm.content,
+  cm.created_at  AS "createdAt"
+FROM circle_messages cm
+JOIN users u ON u.id = cm.user_id
+WHERE cm.circle_id = $1
+  AND ($2::timestamp IS NULL OR cm.created_at < $2)
+ORDER BY cm.created_at ASC
+LIMIT $3
+```
+
+---
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+The project already includes `fast-check@4.6.0` as a dev dependency, making it the natural choice for property-based testing.
+
+### Property Reflection
+
+Before writing properties, reviewing the prework for redundancy:
+
+- **2.2 and 3.2 and 6.2** all test "non-active member gets 403". These can be unified into one property: for any request (GET or POST) from a user with non-active membership status, the API returns 403.
+- **2.4 and 1.2** both test content length enforcement. They can be unified: the system rejects content outside [1, 1000] chars.
+- **3.3 and 3.5** are related but distinct: ordering (3.3) and cursor filtering (3.5) are separate invariants worth keeping separate.
+- **5.3 and 5.5** are UI properties that are independent — form clearing vs. scroll behavior.
+- **7.2 and 7.3 and 7.4** are pagination UI properties that are independent.
+
+After reflection, the consolidated set of properties is:
+
+---
+
+### Property 1: Content length enforcement
+
+*For any* string submitted as `content` in a POST request by an active member, the request SHALL succeed (HTTP 201) if and only if the content length is between 1 and 1000 characters inclusive. Any content outside this range SHALL be rejected with HTTP 400.
+
+**Validates: Requirements 1.2, 2.3, 2.4**
+
+---
+
+### Property 2: Author identity round-trip
+
+*For any* valid `userId` and `content`, after `postMessage(circleId, userId, content)` succeeds, the returned `CircleMessage.userId` SHALL equal the original `userId` exactly.
+
+**Validates: Requirements 1.3, 2.5**
+
+---
+
+### Property 3: Active-member access control
+
+*For any* user whose `members` row for the given circle has a status other than `'active'` (i.e., `'pending'`, `'rejected'`, `'defaulted'`, or `'completed'`), both GET and POST requests to `/api/circles/[id]/chat` SHALL return HTTP 403.
+
+**Validates: Requirements 2.2, 3.2, 6.2**
+
+---
+
+### Property 4: Chronological ordering invariant
+
+*For any* set of messages stored in `circle_messages` for a given circle, the array returned by `getMessages(circleId)` SHALL be sorted in strictly ascending order by `createdAt` (oldest first).
+
+**Validates: Requirements 3.3**
+
+---
+
+### Property 5: Cursor pagination correctness
+
+*For any* ISO 8601 timestamp `before` and any set of messages in the database, every message returned by `getMessages(circleId, { before })` SHALL have `createdAt` strictly less than `before`.
+
+**Validates: Requirements 3.5**
+
+---
+
+### Property 6: Limit parameter enforcement
+
+*For any* integer `limit` in [1, 100], the array returned by `getMessages(circleId, { limit })` SHALL contain at most `limit` messages. When `limit` is omitted, the response SHALL contain at most 50 messages.
+
+**Validates: Requirements 3.4**
+
+---
+
+### Property 7: Response includes display_name
+
+*For any* message returned by `getMessages()` or `postMessage()`, the `CircleMessage` object SHALL include a non-null, non-empty `displayName` field matching the `display_name` of the message author in the `users` table.
+
+**Validates: Requirements 3.6, 4.1**
+
+---
+
+### Property 8: WebSocket broadcast payload completeness
+
+*For any* successfully persisted message, the payload passed to `broadcastChatMessage()` SHALL contain all required fields: `id`, `circleId`, `userId`, `displayName`, `content`, and `createdAt`, each with a non-null value.
+
+**Validates: Requirements 4.1, 2.6**
+
+---
+
+### Property 9: UI appends incoming real-time messages
+
+*For any* `chat:message` WebSocket event received while the `CircleChat` component is mounted, the message SHALL be appended to the end of the displayed message list, and the list length SHALL increase by exactly one.
+
+**Validates: Requirements 4.3**
+
+---
+
+### Property 10: Pagination cursor uses oldest visible message
+
+*For any* non-empty set of messages currently displayed in `CircleChat`, when the "Load earlier messages" control is activated, the GET request SHALL include a `before` query parameter equal to the `createdAt` of the oldest (first) message in the current list.
+
+**Validates: Requirements 7.2**
+
+---
+
+### Property 11: Load-more control visibility
+
+*For any* GET response, the "Load earlier messages" control SHALL be visible if and only if the number of messages returned equals the requested `limit`. When the response contains fewer messages than `limit`, the control SHALL be hidden.
+
+**Validates: Requirements 7.4**
+
+---
+
+## Error Handling
+
+### API Layer
+
+| Condition | HTTP Status | Error Code | Response |
+|-----------|-------------|------------|----------|
+| No session | 401 | `UNAUTHORIZED` | `{ success: false, error: "Unauthorized" }` |
+| User not active member | 403 | `FORBIDDEN` | `{ success: false, error: "Not an active member of this circle" }` |
+| Circle not found | 404 | `NOT_FOUND` | `{ success: false, error: "Circle not found" }` |
+| Missing/empty content | 400 | `VALIDATION_ERROR` | `{ success: false, error: "content is required and must not be empty" }` |
+| Content > 1000 chars | 400 | `VALIDATION_ERROR` | `{ success: false, error: "content must not exceed 1000 characters" }` |
+| Invalid `limit` param | 400 | `VALIDATION_ERROR` | `{ success: false, error: "limit must be an integer between 1 and 100" }` |
+| Invalid `before` param | 400 | `VALIDATION_ERROR` | `{ success: false, error: "before must be a valid ISO 8601 timestamp" }` |
+| Rate limit exceeded | 429 | `RATE_LIMITED` | `{ success: false, error: "Too many requests" }` |
+| DB / unexpected error | 500 | `INTERNAL_ERROR` | `{ success: false, error: "Internal server error" }` |
+
+All errors are wrapped by `withErrorHandler`, which logs via Pino and reports to Sentry.
+
+### Service Layer
+
+- `postMessage` throws if the DB insert fails (e.g., FK violation, constraint violation). The API route's `withErrorHandler` catches and returns 500.
+- `getMessages` throws on DB errors. Same handling.
+- Neither function swallows errors — they propagate to the API layer for consistent error handling.
+
+### WebSocket Layer
+
+- `broadcastChatMessage` is a fire-and-forget call. If `io` is null (server not initialized), it returns silently. This is consistent with the existing broadcast functions.
+- A failed broadcast does NOT roll back the DB insert. The message is persisted; the real-time delivery is best-effort. Clients will see the message on next page load or GET poll.
+
+### Client Layer
+
+- React Query's `isError` / `error` states are surfaced as inline error messages in `CircleChat`.
+- A failed POST does not clear the input field, allowing the user to retry.
+- A failed GET shows an error message with a retry option.
+- WebSocket disconnection is handled by the existing `useRealtimeUpdates` hook (sets `isConnected: false`). The UI degrades gracefully — messages still load via HTTP.
+
+---
+
+## Testing Strategy
+
+### Unit Tests (Jest + `@testing-library/react`)
+
+**`chat.service.ts`**:
+- `postMessage` with valid inputs returns a `CircleMessage` with correct fields
+- `postMessage` with content at boundary (1 char, 1000 chars) succeeds
+- `getMessages` with no options returns up to 50 messages in ascending order
+- `getMessages` with `before` cursor excludes messages at or after the timestamp
+- `getMessages` with `limit` respects the limit
+
+**`/api/circles/[id]/chat/route.ts`**:
+- GET without session → 401
+- GET with non-active member → 403
+- GET with active member → 200 with messages array
+- POST without session → 401
+- POST with non-active member → 403
+- POST with empty content → 400
+- POST with content > 1000 chars → 400
+- POST with valid content → 201 with created message; `broadcastChatMessage` called
+
+**`CircleChat.tsx`**:
+- Renders message list, input, and send button for active members
+- Renders read-only notice for non-members
+- Shows loading indicator while fetching
+- Shows error message on fetch failure
+- Disables send button while POST is in flight
+- Clears input on successful POST
+
+### Property-Based Tests (fast-check)
+
+Each property test runs a minimum of 100 iterations. Tests are tagged with the feature and property number.
+
+```typescript
+// Feature: circle-chat, Property 1: Content length enforcement
+fc.assert(fc.property(
+  fc.string({ minLength: 1001, maxLength: 5000 }),
+  async (content) => {
+    const res = await POST({ content }, activeMemberSession);
+    expect(res.status).toBe(400);
+  }
+), { numRuns: 100 });
+
+fc.assert(fc.property(
+  fc.string({ minLength: 1, maxLength: 1000 }),
+  async (content) => {
+    const res = await POST({ content }, activeMemberSession);
+    expect(res.status).toBe(201);
+  }
+), { numRuns: 100 });
+```
+
+```typescript
+// Feature: circle-chat, Property 2: Author identity round-trip
+fc.assert(fc.property(
+  fc.string({ minLength: 1, maxLength: 1000 }),
+  async (content) => {
+    const message = await postMessage(circleId, userId, content);
+    expect(message.userId).toBe(userId);
+  }
+), { numRuns: 100 });
+```
+
+```typescript
+// Feature: circle-chat, Property 4: Chronological ordering invariant
+fc.assert(fc.property(
+  fc.array(fc.record({ content: fc.string({ minLength: 1, maxLength: 100 }) }), { minLength: 2, maxLength: 20 }),
+  async (messageDefs) => {
+    // Insert messages with varying timestamps
+    const messages = await getMessages(circleId);
+    const timestamps = messages.map(m => new Date(m.createdAt).getTime());
+    for (let i = 1; i < timestamps.length; i++) {
+      expect(timestamps[i]).toBeGreaterThanOrEqual(timestamps[i - 1]);
+    }
+  }
+), { numRuns: 100 });
+```
+
+```typescript
+// Feature: circle-chat, Property 5: Cursor pagination correctness
+fc.assert(fc.property(
+  fc.date({ min: new Date('2020-01-01'), max: new Date('2030-01-01') }),
+  async (before) => {
+    const messages = await getMessages(circleId, { before: before.toISOString() });
+    for (const msg of messages) {
+      expect(new Date(msg.createdAt).getTime()).toBeLessThan(before.getTime());
+    }
+  }
+), { numRuns: 100 });
+```
+
+```typescript
+// Feature: circle-chat, Property 6: Limit parameter enforcement
+fc.assert(fc.property(
+  fc.integer({ min: 1, max: 100 }),
+  async (limit) => {
+    const messages = await getMessages(circleId, { limit });
+    expect(messages.length).toBeLessThanOrEqual(limit);
+  }
+), { numRuns: 100 });
+```
+
+```typescript
+// Feature: circle-chat, Property 7: Response includes display_name
+fc.assert(fc.property(
+  fc.string({ minLength: 1, maxLength: 1000 }),
+  async (content) => {
+    const message = await postMessage(circleId, userId, content);
+    expect(message.displayName).toBeTruthy();
+    expect(typeof message.displayName).toBe('string');
+  }
+), { numRuns: 100 });
+```
+
+### Integration Tests
+
+- End-to-end: POST a message → verify it appears in subsequent GET response
+- WebSocket: POST a message → verify `chat:message` event is emitted to the circle room (using a test socket client)
+- Rate limiting: 31 POST requests from same IP within 60s → 31st returns 429
+
+### Migration Test
+
+- Run `up()` migration → verify `circle_messages` table exists with correct columns and index
+- Run `down()` migration → verify table is dropped

--- a/.kiro/specs/circle-chat/requirements.md
+++ b/.kiro/specs/circle-chat/requirements.md
@@ -1,0 +1,118 @@
+# Requirements Document
+
+## Introduction
+
+Circle Chat adds a persistent message thread to each savings circle, giving members a dedicated space to coordinate payout timing, share updates, and communicate without leaving the app. Each circle has exactly one thread. Messages are stored in the database and delivered in real-time via the existing Socket.io WebSocket infrastructure. Only active members of a circle may read or post messages.
+
+## Glossary
+
+- **Chat_API**: The Next.js API route layer responsible for reading and writing circle messages (`src/app/api/circles/[id]/chat/route.ts`).
+- **Chat_Service**: The server-side service module that executes parameterized SQL queries against the `circle_messages` table.
+- **Chat_UI**: The client-side React component (`CircleChat`) rendered on the circle detail page.
+- **Circle**: A rotating savings group stored in the `circles` table.
+- **Active_Member**: A user whose row in the `members` table has `status = 'active'` for the given circle.
+- **Message**: A single text post in a circle's thread, stored in the `circle_messages` table.
+- **WebSocket_Server**: The existing Socket.io server defined in `src/server/websocket.ts`.
+- **Realtime_Hook**: The existing `useRealtimeUpdates` React hook in `src/hooks/useRealtimeUpdates.ts`.
+- **Session**: A NextAuth.js JWT session obtained via `getServerSession(authOptions)`.
+
+---
+
+## Requirements
+
+### Requirement 1: Message Storage
+
+**User Story:** As a circle member, I want my messages to be saved, so that I can read the conversation history when I return to the circle page.
+
+#### Acceptance Criteria
+
+1. THE Chat_Service SHALL store each Message in a `circle_messages` table with columns: `id` (UUID), `circle_id` (UUID FK → circles), `user_id` (VARCHAR FK → users), `content` (TEXT), and `created_at` (TIMESTAMP DEFAULT NOW()).
+2. THE Chat_Service SHALL enforce a maximum content length of 1000 characters per Message at the database constraint level.
+3. WHEN a Message is stored, THE Chat_Service SHALL record the `user_id` of the author exactly as provided by the authenticated Session.
+4. THE Chat_Service SHALL index the `circle_messages` table on `circle_id` and `created_at` to support efficient chronological retrieval.
+
+---
+
+### Requirement 2: Post a Message
+
+**User Story:** As an active circle member, I want to post a message to my circle's thread, so that I can communicate with other members.
+
+#### Acceptance Criteria
+
+1. WHEN an authenticated user submits a POST request to `/api/circles/[id]/chat`, THE Chat_API SHALL verify the user has an active Session before processing the request.
+2. WHEN a POST request is received and the requesting user is not an Active_Member of the circle, THE Chat_API SHALL return HTTP 403 with a descriptive error.
+3. WHEN a POST request is received with a missing or empty `content` field, THE Chat_API SHALL return HTTP 400 with a descriptive validation error.
+4. WHEN a POST request is received with `content` exceeding 1000 characters, THE Chat_API SHALL return HTTP 400 with a descriptive validation error.
+5. WHEN a valid POST request is received from an Active_Member, THE Chat_API SHALL persist the Message via the Chat_Service and return HTTP 201 with the created Message object.
+6. WHEN a Message is successfully persisted, THE Chat_API SHALL emit a `chat:message` WebSocket event to the `circle:{id}` room via the WebSocket_Server.
+
+---
+
+### Requirement 3: Retrieve Messages
+
+**User Story:** As an active circle member, I want to load the message history for my circle, so that I can read past conversations.
+
+#### Acceptance Criteria
+
+1. WHEN an authenticated user submits a GET request to `/api/circles/[id]/chat`, THE Chat_API SHALL verify the user has an active Session before processing the request.
+2. WHEN a GET request is received and the requesting user is not an Active_Member of the circle, THE Chat_API SHALL return HTTP 403 with a descriptive error.
+3. WHEN a valid GET request is received, THE Chat_API SHALL return messages in ascending chronological order (oldest first).
+4. THE Chat_API SHALL support a `limit` query parameter (integer, 1–100, default 50) to control the number of messages returned.
+5. THE Chat_API SHALL support a `before` query parameter (ISO 8601 timestamp) to enable cursor-based pagination of older messages.
+6. WHEN a valid GET request is received, THE Chat_API SHALL include the author's `display_name` alongside each Message in the response.
+
+---
+
+### Requirement 4: Real-Time Message Delivery
+
+**User Story:** As an active circle member, I want new messages to appear instantly without refreshing the page, so that the conversation feels live.
+
+#### Acceptance Criteria
+
+1. WHEN a Message is successfully persisted, THE WebSocket_Server SHALL broadcast a `chat:message` event containing the full Message object (including `id`, `circleId`, `userId`, `displayName`, `content`, `createdAt`) to all sockets in the `circle:{id}` room.
+2. WHEN the Chat_UI mounts, THE Realtime_Hook SHALL subscribe to `chat:message` events for the current circle.
+3. WHEN a `chat:message` event is received, THE Chat_UI SHALL append the new Message to the displayed thread without requiring a page reload.
+4. WHEN the Chat_UI unmounts, THE Realtime_Hook SHALL unsubscribe from `chat:message` events for the current circle.
+
+---
+
+### Requirement 5: Chat UI Component
+
+**User Story:** As a circle member, I want a clear and usable chat interface on the circle detail page, so that I can read and send messages without navigating away.
+
+#### Acceptance Criteria
+
+1. THE Chat_UI SHALL render a scrollable message list and a text input with a send button within the circle detail page.
+2. WHEN the Chat_UI mounts, THE Chat_UI SHALL fetch the initial message history via the GET `/api/circles/[id]/chat` endpoint using React Query.
+3. WHEN a user submits the message input form, THE Chat_UI SHALL POST the message to `/api/circles/[id]/chat` and clear the input field on success.
+4. WHEN a POST request is in flight, THE Chat_UI SHALL disable the send button to prevent duplicate submissions.
+5. WHEN the message list updates, THE Chat_UI SHALL automatically scroll to the most recent message.
+6. IF the user is not an Active_Member of the circle, THE Chat_UI SHALL render a read-only notice in place of the message input.
+7. WHILE the initial message history is loading, THE Chat_UI SHALL display a loading indicator.
+8. IF the GET or POST request fails, THE Chat_UI SHALL display a descriptive inline error message.
+
+---
+
+### Requirement 6: Access Control
+
+**User Story:** As a circle creator, I want only active members to participate in the chat, so that the conversation remains private to the group.
+
+#### Acceptance Criteria
+
+1. WHEN any request reaches `/api/circles/[id]/chat` without a valid Session, THE Chat_API SHALL return HTTP 401.
+2. WHEN any request reaches `/api/circles/[id]/chat` from a user whose `members` row has a status other than `active`, THE Chat_API SHALL return HTTP 403.
+3. THE Chat_API SHALL apply the existing `withRateLimit` middleware to the chat endpoint, limiting each IP to 30 POST requests per minute.
+4. THE Chat_API SHALL use parameterized SQL queries for all database interactions to prevent SQL injection.
+
+---
+
+### Requirement 7: Message Pagination
+
+**User Story:** As a circle member, I want to load older messages on demand, so that I can review conversation history without loading everything at once.
+
+#### Acceptance Criteria
+
+1. WHEN the Chat_UI reaches the top of the message list, THE Chat_UI SHALL display a "Load earlier messages" control.
+2. WHEN the "Load earlier messages" control is activated, THE Chat_UI SHALL issue a GET request with the `before` parameter set to the `createdAt` timestamp of the oldest currently displayed Message.
+3. WHEN older messages are returned, THE Chat_UI SHALL prepend them to the message list while preserving the current scroll position.
+4. WHEN the GET response returns fewer messages than the requested `limit`, THE Chat_UI SHALL hide the "Load earlier messages" control.

--- a/.kiro/specs/circle-chat/tasks.md
+++ b/.kiro/specs/circle-chat/tasks.md
@@ -1,0 +1,172 @@
+# Implementation Plan: Circle Chat
+
+## Overview
+
+Implement a persistent, real-time message thread for each savings circle. The work proceeds in five incremental stages: database schema, service layer, API route, WebSocket integration, and the React UI — each building on the previous so nothing is left unconnected.
+
+## Tasks
+
+- [x] 1. Add the `circle_messages` database migration
+  - Create `migrations/1746200000000_add-circle-messages-table.ts` following the pattern in `migrations/1746100000000_add-contribution-reminders-table.ts`
+  - Define the table with columns: `id` (UUID PK), `circle_id` (UUID FK → circles CASCADE), `user_id` (VARCHAR FK → users CASCADE), `content` (TEXT with `char_length` check 1–1000), `created_at` (TIMESTAMP DEFAULT NOW())
+  - Add composite index `idx_circle_messages_circle_created` on `(circle_id, created_at)`
+  - Implement `down()` to drop the table
+  - _Requirements: 1.1, 1.2, 1.4_
+
+- [x] 2. Add `CircleMessage` type and extend WebSocket types
+  - [x] 2.1 Add `CircleMessage` interface to `src/types/index.ts`
+    - Fields: `id`, `circleId`, `userId`, `displayName`, `content`, `createdAt` (ISO string)
+    - _Requirements: 1.1, 3.6_
+
+  - [x] 2.2 Extend `WebSocketEvents` and add `broadcastChatMessage()` in `src/server/websocket.ts`
+    - Add `"chat:message"` key to the `WebSocketEvents` interface with fields matching `CircleMessage`
+    - Add `broadcastChatMessage(circleId: string, message: WebSocketEvents["chat:message"]): void` following the `broadcastContributionConfirmed` pattern
+    - _Requirements: 4.1, 2.6_
+
+- [x] 3. Implement `chat.service.ts`
+  - [x] 3.1 Create `src/server/services/chat.service.ts` with `postMessage()`
+    - Import `query` from `@/lib/db` and `CircleMessage` from `@/types`
+    - `postMessage(circleId, userId, content)`: INSERT into `circle_messages`, then SELECT with JOIN on `users` to return the full `CircleMessage` including `displayName`
+    - Use camelCase column aliases matching the pattern in `circle.service.ts`
+    - _Requirements: 1.3, 2.5, 3.6_
+
+  - [ ]* 3.2 Write property test for `postMessage` — author identity round-trip
+    - **Property 2: Author identity round-trip**
+    - For any valid `content`, `postMessage(circleId, userId, content).userId` SHALL equal the original `userId`
+    - **Validates: Requirements 1.3, 2.5**
+
+  - [ ]* 3.3 Write property test for `postMessage` — response includes display_name
+    - **Property 7: Response includes display_name**
+    - For any valid `content`, the returned `CircleMessage.displayName` SHALL be a non-empty string
+    - **Validates: Requirements 3.6, 4.1**
+
+  - [x] 3.4 Add `getMessages()` to `src/server/services/chat.service.ts`
+    - `getMessages(circleId, options?)`: SELECT with JOIN on `users`, WHERE `circle_id = $1 AND ($2::timestamp IS NULL OR created_at < $2)`, ORDER BY `created_at ASC`, LIMIT `$3`
+    - Accept `GetMessagesOptions` interface: `{ limit?: number; before?: string }`
+    - Default `limit` to 50; clamp to [1, 100]
+    - _Requirements: 3.3, 3.4, 3.5_
+
+  - [ ]* 3.5 Write property test for `getMessages` — chronological ordering invariant
+    - **Property 4: Chronological ordering invariant**
+    - For any set of stored messages, `getMessages(circleId)` SHALL return them in strictly ascending `createdAt` order
+    - **Validates: Requirements 3.3**
+
+  - [ ]* 3.6 Write property test for `getMessages` — cursor pagination correctness
+    - **Property 5: Cursor pagination correctness**
+    - For any ISO timestamp `before`, every message returned by `getMessages(circleId, { before })` SHALL have `createdAt` strictly less than `before`
+    - **Validates: Requirements 3.5**
+
+  - [ ]* 3.7 Write property test for `getMessages` — limit parameter enforcement
+    - **Property 6: Limit parameter enforcement**
+    - For any integer `limit` in [1, 100], `getMessages(circleId, { limit })` SHALL return at most `limit` messages; with no `limit`, at most 50
+    - **Validates: Requirements 3.4**
+
+  - [ ]* 3.8 Write unit tests for `chat.service.ts`
+    - `postMessage` with content at boundaries (1 char, 1000 chars) succeeds
+    - `getMessages` with no options returns up to 50 messages
+    - `getMessages` with `before` excludes messages at or after the timestamp
+    - _Requirements: 1.2, 3.3, 3.4, 3.5_
+
+- [x] 4. Checkpoint — service layer complete
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 5. Implement the chat API route
+  - [x] 5.1 Create `src/app/api/circles/[id]/chat/route.ts` with GET handler
+    - Wrap with `withErrorHandler`; call `getServerSession` → 401 if no session
+    - Query `members` table to verify `status = 'active'` for the requesting user → 403 if not active member
+    - Parse and validate `limit` (integer 1–100, default 50) and `before` (valid ISO 8601) query params → 400 on invalid
+    - Call `getMessages(circleId, { limit, before })` and return `200 ApiResponse<CircleMessage[]>`
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 6.1, 6.2, 6.4_
+
+  - [x] 5.2 Add POST handler to `src/app/api/circles/[id]/chat/route.ts`
+    - Wrap with `withErrorHandler` and `withRateLimit({ limit: 30, windowMs: 60_000 })`
+    - Auth check (401), active-member check (403), content validation (400 for empty or >1000 chars)
+    - Call `postMessage(circleId, userId, content)`, then `broadcastChatMessage(circleId, message)`
+    - Return `201 ApiResponse<CircleMessage>`
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 6.1, 6.2, 6.3, 6.4_
+
+  - [ ]* 5.3 Write property test for the API route — content length enforcement
+    - **Property 1: Content length enforcement**
+    - For any `content` with length > 1000, POST SHALL return 400; for length in [1, 1000], POST SHALL return 201
+    - **Validates: Requirements 1.2, 2.3, 2.4**
+
+  - [ ]* 5.4 Write property test for the API route — active-member access control
+    - **Property 3: Active-member access control**
+    - For any user with member `status` other than `'active'`, both GET and POST SHALL return 403
+    - **Validates: Requirements 2.2, 3.2, 6.2**
+
+  - [ ]* 5.5 Write unit tests for the API route
+    - GET without session → 401; GET with non-active member → 403; GET with active member → 200
+    - POST without session → 401; POST with non-active member → 403; POST with empty content → 400; POST with content > 1000 chars → 400
+    - POST with valid content → 201; `broadcastChatMessage` called once
+    - _Requirements: 2.1–2.6, 3.1–3.2, 6.1–6.3_
+
+- [x] 6. Checkpoint — API route complete
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 7. Extend `useRealtimeUpdates` hook
+  - Add `onChatMessage?: (data: WebSocketEvents["chat:message"]) => void` to the `UseRealtimeUpdatesOptions` interface in `src/hooks/useRealtimeUpdates.ts`
+  - Inside the `useEffect`, add `if (onChatMessage) { socket.on("chat:message", onChatMessage); }` following the existing `onContributionConfirmed` pattern
+  - Add `onChatMessage` to the `useEffect` dependency array
+  - _Requirements: 4.2, 4.4_
+
+- [x] 8. Build the `CircleChat` component
+  - [x] 8.1 Create `src/components/circle/CircleChat.tsx`
+    - Accept props: `circleId: string`, `isActiveMember: boolean`, `currentUserId: string`
+    - Use `useQuery` (React Query) to fetch initial messages from `GET /api/circles/[id]/chat`
+    - Use `useMutation` to POST new messages; clear input on success; keep input populated on error
+    - Use `useRealtimeUpdates({ circleId, onChatMessage })` to append incoming `chat:message` events to the local message list (increment list by exactly one per event)
+    - Render a scrollable message list; auto-scroll to the newest message on list update
+    - Render a text input + send button for active members; disable send button while mutation is in flight
+    - Render a read-only notice for non-active members
+    - Show a loading indicator while the initial query is loading
+    - Show an inline error message on GET or POST failure
+    - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 5.8, 4.2, 4.3, 4.4_
+
+  - [ ]* 8.2 Write property test for `CircleChat` — UI appends incoming real-time messages
+    - **Property 9: UI appends incoming real-time messages**
+    - For any `chat:message` WebSocket event received while the component is mounted, the message SHALL be appended to the end of the list and the list length SHALL increase by exactly one
+    - **Validates: Requirements 4.3**
+
+  - [ ]* 8.3 Write property test for `CircleChat` — pagination cursor uses oldest visible message
+    - **Property 10: Pagination cursor uses oldest visible message**
+    - When "Load earlier messages" is activated, the GET request SHALL include `before` equal to the `createdAt` of the oldest displayed message
+    - **Validates: Requirements 7.2**
+
+  - [ ]* 8.4 Write property test for `CircleChat` — load-more control visibility
+    - **Property 11: Load-more control visibility**
+    - The "Load earlier messages" control SHALL be visible iff the response count equals the requested `limit`; hidden when fewer messages are returned
+    - **Validates: Requirements 7.4**
+
+  - [ ]* 8.5 Write unit tests for `CircleChat.tsx`
+    - Renders message list, input, and send button for active members
+    - Renders read-only notice for non-active members
+    - Shows loading indicator while fetching
+    - Shows error message on fetch failure
+    - Disables send button while POST is in flight
+    - Clears input on successful POST
+    - _Requirements: 5.1–5.8_
+
+  - [x] 8.6 Create `src/components/circle/CircleChat.module.css`
+    - Scoped styles for the chat container, message list, individual messages, author name, timestamp, input area, send button, and load-earlier control
+    - Follow the CSS Modules pattern used in `CircleCard.module.css`
+    - _Requirements: 5.1_
+
+- [x] 9. Wire `CircleChat` into the circle detail page
+  - Modify `src/app/circles/[id]/page.tsx` to import and render `<CircleChat>` below the existing grid
+  - Determine `isActiveMember` from the existing `members` array (`members.some(m => m.userId === userId && m.status === 'active')`)
+  - Pass `circleId={circle.id}`, `isActiveMember`, and `currentUserId={userId ?? ''}` as props
+  - Only render `<CircleChat>` when `userId` is defined (user is logged in)
+  - _Requirements: 5.1, 5.6, 6.1_
+
+- [x] 10. Final checkpoint — Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for a faster MVP
+- Each task references specific requirements for traceability
+- Property tests use `fast-check` (already installed as a dev dependency)
+- Unit tests use Jest + `@testing-library/react` (already configured)
+- The WebSocket broadcast is fire-and-forget; a failed broadcast does not roll back the DB insert
+- The `before` cursor is an ISO 8601 timestamp; pass it as `$2::timestamp` in SQL to handle null safely

--- a/.kiro/specs/contribution-reminders/.config.kiro
+++ b/.kiro/specs/contribution-reminders/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "6f502639-a32f-4049-8dbc-5b8b97545719", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/contribution-reminders/design.md
+++ b/.kiro/specs/contribution-reminders/design.md
@@ -1,0 +1,301 @@
+# Design Document: Contribution Reminders
+
+## Overview
+
+This feature adds automated SMS reminders to Ajosave that prompt active circle members to contribute before the cycle deadline (`next_payout_at`). Two reminder windows are supported: 24 hours before the deadline and 2 hours before the deadline. The system is designed to be idempotent — each member receives at most one reminder per window per cycle, regardless of how many times the cron runs while the circle is inside a window.
+
+The implementation extends the existing cron-based notification infrastructure without modifying any existing endpoints or services. It introduces:
+
+- A new `sendContributionReminderSms` function in `src/lib/sms.ts`
+- A new `notifyContributionReminder` function in `src/server/services/notification.service.ts`
+- A new `sendContributionReminders` function in `src/server/services/scheduler.service.ts`
+- A new cron endpoint at `src/app/api/cron/contribution-reminders/route.ts`
+- A new `contribution_reminders` database table for idempotency tracking
+- A migration file to create the idempotency table
+
+### Key Design Decisions
+
+**Idempotency via a dedicated tracking table** — The requirements mandate at most one reminder per window per member per cycle. The cleanest approach is a `contribution_reminders` table with a unique constraint on `(member_id, cycle_number, reminder_type)`. This is preferred over adding columns to the `contributions` table (which conflates two concerns) and over relying on contribution record status (which doesn't exist for members who haven't initiated payment yet).
+
+**Hourly cron cadence** — Both reminder windows are 2 hours wide (23–25h and 1–3h), so an hourly cron is sufficient to guarantee each window is checked at least once. This matches the existing payout-reminder cron cadence.
+
+**No changes to existing services** — The new scheduler function is additive. Existing `sendPayoutReminders` and `processMissedContributions` functions are untouched.
+
+---
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant Cron as Vercel Cron (hourly)
+    participant Endpoint as GET /api/cron/contribution-reminders
+    participant Auth as verifyCronSecret()
+    participant Scheduler as sendContributionReminders()
+    participant DB as PostgreSQL
+    participant Notify as notifyContributionReminder()
+    participant SMS as sendContributionReminderSms()
+    participant Termii as Termii API
+
+    Cron->>Endpoint: GET with Authorization: Bearer <CRON_SECRET>
+    Endpoint->>Auth: verifyCronSecret(req)
+    Auth-->>Endpoint: null (authenticated)
+    Endpoint->>Scheduler: sendContributionReminders()
+
+    loop For each reminder window [24h, 2h]
+        Scheduler->>DB: Query active circles in window
+        loop For each circle
+            Scheduler->>DB: Query active members
+            loop For each member
+                Scheduler->>DB: Check contribution status (pending/no record)
+                Scheduler->>DB: Check idempotency (contribution_reminders table)
+                alt Not yet reminded this window/cycle
+                    Scheduler->>Notify: notifyContributionReminder(userId, ...)
+                    Notify->>DB: Check sms_notifications_enabled
+                    Notify->>DB: Get phone number
+                    Notify->>SMS: sendContributionReminderSms(phone, ...)
+                    SMS->>Termii: POST /sms/send
+                    Scheduler->>DB: INSERT into contribution_reminders
+                end
+            end
+        end
+    end
+
+    Endpoint-->>Cron: 200 { success: true }
+```
+
+---
+
+## Components and Interfaces
+
+### `src/lib/sms.ts` — New function
+
+```typescript
+/**
+ * Send a contribution reminder SMS.
+ * @param phone       Recipient phone number
+ * @param circleName  Name of the circle
+ * @param amount      Contribution amount in USDC (formatted string)
+ * @param hoursLeft   Hours remaining until the cycle deadline (24 or 2)
+ */
+export async function sendContributionReminderSms(
+  phone: string,
+  circleName: string,
+  amount: string,
+  hoursLeft: number
+): Promise<void>
+```
+
+Message format:
+```
+Ajosave: Your contribution of <amount> USDC to "<circleName>" is due in <hoursLeft> hours. Please contribute now to avoid being marked as defaulted!
+```
+
+### `src/server/services/notification.service.ts` — New function
+
+```typescript
+/**
+ * Send a contribution reminder to a single member.
+ * Respects the user's sms_notifications_enabled preference.
+ * Errors are caught and logged; they do not propagate.
+ */
+export async function notifyContributionReminder(
+  userId: string,
+  circleName: string,
+  amount: string,
+  hoursLeft: number
+): Promise<void>
+```
+
+Follows the same pattern as `notifyPayoutReminder`:
+1. `canSendSms(userId)` — return early if disabled
+2. `getUserPhone(userId)` — return early if no phone
+3. `sendContributionReminderSms(phone, ...)` — wrapped in try/catch
+
+### `src/server/services/scheduler.service.ts` — New function
+
+```typescript
+/**
+ * Send contribution reminders for both the 24h and 2h windows.
+ * Idempotent: uses the contribution_reminders table to prevent duplicates.
+ * Per-circle errors are caught and logged; they do not abort the run.
+ */
+export async function sendContributionReminders(): Promise<void>
+```
+
+Internal logic:
+
+```typescript
+type ReminderWindow = { hoursLeft: number; lowerBound: string; upperBound: string };
+
+const WINDOWS: ReminderWindow[] = [
+  { hoursLeft: 24, lowerBound: '23 hours', upperBound: '25 hours' },
+  { hoursLeft: 2,  lowerBound: '1 hour',   upperBound: '3 hours'  },
+];
+```
+
+For each window:
+1. Query circles: `status = 'active' AND next_payout_at IS NOT NULL AND next_payout_at > NOW() + INTERVAL '<lower>' AND next_payout_at < NOW() + INTERVAL '<upper>'`
+2. For each circle, query active members
+3. For each member, check if they are a Pending_Contributor (no contribution record for current cycle, or contribution with `status = 'pending'`)
+4. Check idempotency: `SELECT 1 FROM contribution_reminders WHERE member_id = $1 AND cycle_number = $2 AND reminder_type = $3`
+5. If not already reminded: call `notifyContributionReminder`, then `INSERT INTO contribution_reminders`
+
+### `src/app/api/cron/contribution-reminders/route.ts` — New endpoint
+
+```typescript
+export async function GET(req: NextRequest): Promise<NextResponse>
+```
+
+Pattern mirrors `src/app/api/cron/reminders/route.ts`:
+1. `verifyCronSecret(req)` — return 401 if invalid
+2. `sendContributionReminders()` — wrapped in try/catch
+3. Return `200 { success: true }` on success
+4. Return `500 { success: false, error: message }` on unhandled error
+
+---
+
+## Data Models
+
+### New table: `contribution_reminders`
+
+```sql
+CREATE TABLE contribution_reminders (
+  id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  member_id     UUID        NOT NULL REFERENCES members(id) ON DELETE CASCADE,
+  cycle_number  INTEGER     NOT NULL CHECK (cycle_number > 0),
+  reminder_type VARCHAR(4)  NOT NULL CHECK (reminder_type IN ('24h', '2h')),
+  sent_at       TIMESTAMP   NOT NULL DEFAULT NOW(),
+  UNIQUE (member_id, cycle_number, reminder_type)
+);
+
+CREATE INDEX idx_contribution_reminders_member ON contribution_reminders (member_id, cycle_number);
+```
+
+The `UNIQUE (member_id, cycle_number, reminder_type)` constraint is the idempotency guarantee. Even if two cron runs overlap, only one `INSERT` will succeed; the second will be silently ignored via `ON CONFLICT DO NOTHING`.
+
+### Migration file
+
+`migrations/<timestamp>_add-contribution-reminders-table.ts`
+
+Uses `node-pg-migrate` following the pattern of existing migrations.
+
+### Existing tables used (read-only)
+
+| Table | Columns read |
+|---|---|
+| `circles` | `id`, `name`, `status`, `next_payout_at`, `current_cycle`, `contribution_usdc` |
+| `members` | `id`, `user_id`, `circle_id`, `status` |
+| `contributions` | `member_id`, `cycle_number`, `status` |
+| `users` | `sms_notifications_enabled`, `phone` |
+
+---
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Circle window filtering
+
+*For any* set of circles with varying `status` values and `next_payout_at` timestamps, the Contribution_Reminder_Service SHALL select exactly those circles that are `active`, have a non-null `next_payout_at`, and whose deadline falls within the specified reminder window — and no others.
+
+**Validates: Requirements 1.1, 7.1, 7.2**
+
+### Property 2: Pending contributor classification
+
+*For any* active circle member and any possible contribution state (no record, `pending`, `confirmed`, `missed`), the Contribution_Reminder_Service SHALL classify the member as a Pending_Contributor if and only if the member has no contribution record for the current cycle or the record has `status = 'pending'`.
+
+**Validates: Requirements 1.2, 1.3, 1.4, 1.5**
+
+### Property 3: SMS message content
+
+*For any* circle name, contribution amount, and hours-remaining value (24 or 2), the `sendContributionReminderSms` function SHALL produce a message that contains the circle name, the contribution amount, the hours remaining, and is prefixed with "Ajosave:".
+
+**Validates: Requirements 2.2, 3.2, 5.2, 5.3**
+
+### Property 4: Opt-out is always respected
+
+*For any* Pending_Contributor with `sms_notifications_enabled = false`, the Contribution_Reminder_Service SHALL never invoke `sendContributionReminderSms` for that member, regardless of which reminder window is active.
+
+**Validates: Requirements 2.3, 3.3**
+
+### Property 5: Per-circle fault isolation
+
+*For any* run of `sendContributionReminders` where one or more circles cause an error during processing, the service SHALL continue processing all remaining circles and SHALL NOT propagate the error to the caller.
+
+**Validates: Requirements 2.4, 3.4, 7.3**
+
+### Property 6: Idempotency — at most one reminder per window per cycle
+
+*For any* Pending_Contributor and any number of invocations of `sendContributionReminders` while a circle remains within the same reminder window and cycle, the member SHALL receive at most one SMS for that window and cycle combination.
+
+**Validates: Requirements 6.1, 6.2, 6.3**
+
+### Property 7: Unauthorized requests are always rejected
+
+*For any* request to `GET /api/cron/contribution-reminders` that does not carry a valid `Authorization: Bearer <CRON_SECRET>` header (including missing header, wrong token, or malformed header), the endpoint SHALL return 401 and SHALL NOT invoke `sendContributionReminders`.
+
+**Validates: Requirements 4.3**
+
+---
+
+## Error Handling
+
+| Failure scenario | Handling |
+|---|---|
+| Missing or invalid `CRON_SECRET` | `verifyCronSecret` returns 401; service is never called |
+| `sendContributionReminders` throws | Endpoint catches, returns `500 { success: false, error: message }` |
+| Error processing a single circle | Caught inside the circle loop; logged; remaining circles continue |
+| SMS delivery failure for a member | Caught inside `notifyContributionReminder`; logged; remaining members continue |
+| User has no phone number | `getUserPhone` returns null; `notifyContributionReminder` returns early |
+| User has SMS disabled | `canSendSms` returns false; `notifyContributionReminder` returns early |
+| Duplicate reminder INSERT | `ON CONFLICT DO NOTHING` on `contribution_reminders`; silently ignored |
+| Circle has null `next_payout_at` | Excluded by the SQL `WHERE next_payout_at IS NOT NULL` clause |
+
+---
+
+## Testing Strategy
+
+### Unit tests
+
+Unit tests cover specific examples and edge cases using Jest (the existing test runner):
+
+- `sendContributionReminderSms` formats the message correctly for both 24h and 2h
+- `notifyContributionReminder` skips users with SMS disabled
+- `notifyContributionReminder` skips users with no phone number
+- `notifyContributionReminder` catches and logs SMS errors without throwing
+- Cron endpoint returns 401 for missing/invalid auth
+- Cron endpoint returns 500 when the service throws
+- Cron endpoint returns 200 on success
+
+### Property-based tests
+
+Property-based tests use [fast-check](https://github.com/dubzzz/fast-check), which is already a transitive dependency in the project. Each test runs a minimum of 100 iterations.
+
+Each test is tagged with a comment in the format:
+`// Feature: contribution-reminders, Property <N>: <property_text>`
+
+**Property 1 — Circle window filtering**
+Generate arbitrary arrays of circles with random statuses and `next_payout_at` offsets. Call the filtering logic and assert the result contains exactly the circles that are active, non-null deadline, and within the window.
+
+**Property 2 — Pending contributor classification**
+Generate arbitrary members paired with arbitrary contribution states (no record / pending / confirmed / missed). Call the classification logic and assert the result matches the expected pending/not-pending outcome.
+
+**Property 3 — SMS message content**
+Generate arbitrary circle names (including special characters, Unicode), amounts, and hours values. Call `sendContributionReminderSms` with a mocked `sendSms` and assert the captured message contains the circle name, amount, hours, and starts with "Ajosave:".
+
+**Property 4 — Opt-out is always respected**
+Generate arbitrary users with `sms_notifications_enabled = false`. Mock the DB and SMS layer. Call `notifyContributionReminder` and assert `sendSms` is never called.
+
+**Property 5 — Per-circle fault isolation**
+Generate an arbitrary list of circles where a random subset throws during processing. Call `sendContributionReminders` and assert it completes without throwing and that non-failing circles are processed.
+
+**Property 6 — Idempotency**
+Generate an arbitrary Pending_Contributor and simulate N invocations (N ≥ 2) of `sendContributionReminders` for the same circle/cycle/window. Assert `sendSms` is called exactly once across all invocations.
+
+**Property 7 — Unauthorized requests are always rejected**
+Generate arbitrary strings as Authorization header values (excluding the valid secret). Call the cron endpoint handler and assert all return 401 without invoking the service.
+
+### Integration tests
+
+- End-to-end: seed a circle with pending members, invoke the cron endpoint with a valid secret, verify the `contribution_reminders` table is populated and SMS mock was called the correct number of times.
+- Verify the `contribution_reminders` unique constraint prevents duplicate rows.

--- a/.kiro/specs/contribution-reminders/requirements.md
+++ b/.kiro/specs/contribution-reminders/requirements.md
@@ -1,0 +1,109 @@
+# Requirements Document
+
+## Introduction
+
+This feature adds automated contribution reminder notifications to Ajosave. Active circle members who have not yet confirmed their contribution for the current cycle will receive SMS reminders at 24 hours and 2 hours before the cycle deadline (`next_payout_at`). The goal is to reduce missed contributions and member defaults by prompting timely payment.
+
+The feature extends the existing cron-based notification infrastructure. A new cron endpoint will run hourly (reusing the same cadence as the payout-reminder cron) and query for circles whose deadline falls within the relevant reminder windows. It will send SMS messages only to members who have not yet confirmed their contribution and who have SMS notifications enabled.
+
+## Glossary
+
+- **Contribution_Reminder_Service**: The service layer component responsible for identifying members who need contribution reminders and dispatching SMS notifications.
+- **Reminder_Cron**: The HTTP endpoint at `/api/cron/contribution-reminders` that is invoked on a schedule to trigger the Contribution_Reminder_Service.
+- **Cycle_Deadline**: The `next_payout_at` timestamp on a circle, representing the point in time by which all members must have confirmed their contribution for the current cycle.
+- **Pending_Contributor**: An active circle member whose contribution for the current cycle has a status of `pending` or has no contribution record at all (i.e., has not yet initiated or confirmed payment).
+- **SMS_Notification_System**: The existing Termii-backed system comprising `src/lib/sms.ts` and `src/server/services/notification.service.ts`.
+- **CRON_SECRET**: The shared secret used to authenticate requests to cron endpoints via `Authorization: Bearer <CRON_SECRET>`.
+- **Reminder_Window**: A time range used to identify circles whose deadline is approaching. The 24-hour window is 23–25 hours before the deadline; the 2-hour window is 1–3 hours before the deadline.
+
+---
+
+## Requirements
+
+### Requirement 1: Identify Members Requiring Contribution Reminders
+
+**User Story:** As a circle operator, I want the system to automatically identify which active members have not yet contributed before a cycle deadline, so that reminders can be sent to the right people.
+
+#### Acceptance Criteria
+
+1. WHEN the Contribution_Reminder_Service is invoked, THE Contribution_Reminder_Service SHALL query all circles with `status = 'active'` and a `next_payout_at` value within a specified Reminder_Window.
+2. WHEN a circle is identified within a Reminder_Window, THE Contribution_Reminder_Service SHALL retrieve all members of that circle with `status = 'active'`.
+3. WHEN evaluating each active member, THE Contribution_Reminder_Service SHALL classify a member as a Pending_Contributor if the member has no contribution record for the current cycle, or if the member's contribution record for the current cycle has `status = 'pending'`.
+4. THE Contribution_Reminder_Service SHALL NOT classify a member as a Pending_Contributor if the member's contribution for the current cycle has `status = 'confirmed'`.
+5. THE Contribution_Reminder_Service SHALL NOT classify a member as a Pending_Contributor if the member's contribution for the current cycle has `status = 'missed'`.
+
+---
+
+### Requirement 2: Send 24-Hour Contribution Reminder
+
+**User Story:** As a circle member, I want to receive an SMS reminder 24 hours before the contribution deadline, so that I have enough time to make my payment.
+
+#### Acceptance Criteria
+
+1. WHEN the Contribution_Reminder_Service is invoked and a circle's `next_payout_at` is between 23 and 25 hours from the current time, THE Contribution_Reminder_Service SHALL send a contribution reminder SMS to each Pending_Contributor in that circle.
+2. WHEN sending a 24-hour reminder, THE SMS_Notification_System SHALL deliver a message that includes the circle name, the contribution amount in USDC, and the number of hours remaining (24).
+3. IF a Pending_Contributor has `sms_notifications_enabled = false`, THEN THE Contribution_Reminder_Service SHALL skip sending an SMS to that member.
+4. IF the SMS_Notification_System fails to deliver a message to a Pending_Contributor, THEN THE Contribution_Reminder_Service SHALL log the error and continue processing remaining members without throwing.
+
+---
+
+### Requirement 3: Send 2-Hour Contribution Reminder
+
+**User Story:** As a circle member, I want to receive a final SMS reminder 2 hours before the contribution deadline, so that I have a last-chance prompt to contribute before being marked as defaulted.
+
+#### Acceptance Criteria
+
+1. WHEN the Contribution_Reminder_Service is invoked and a circle's `next_payout_at` is between 1 and 3 hours from the current time, THE Contribution_Reminder_Service SHALL send a contribution reminder SMS to each Pending_Contributor in that circle.
+2. WHEN sending a 2-hour reminder, THE SMS_Notification_System SHALL deliver a message that includes the circle name, the contribution amount in USDC, and the number of hours remaining (2).
+3. IF a Pending_Contributor has `sms_notifications_enabled = false`, THEN THE Contribution_Reminder_Service SHALL skip sending an SMS to that member.
+4. IF the SMS_Notification_System fails to deliver a message to a Pending_Contributor, THEN THE Contribution_Reminder_Service SHALL log the error and continue processing remaining members without throwing.
+
+---
+
+### Requirement 4: Cron Endpoint for Contribution Reminders
+
+**User Story:** As a system operator, I want a dedicated cron endpoint that triggers contribution reminders on a schedule, so that reminders are sent automatically without manual intervention.
+
+#### Acceptance Criteria
+
+1. THE Reminder_Cron SHALL expose a `GET /api/cron/contribution-reminders` HTTP endpoint.
+2. WHEN a request is received at `GET /api/cron/contribution-reminders` with a valid `Authorization: Bearer <CRON_SECRET>` header, THE Reminder_Cron SHALL invoke the Contribution_Reminder_Service and return a `200 OK` response with `{ success: true }`.
+3. WHEN a request is received at `GET /api/cron/contribution-reminders` without a valid `Authorization: Bearer <CRON_SECRET>` header, THE Reminder_Cron SHALL return a `401 Unauthorized` response without invoking the Contribution_Reminder_Service.
+4. IF the Contribution_Reminder_Service throws an unhandled error, THEN THE Reminder_Cron SHALL return a `500` response with `{ success: false, error: "<message>" }`.
+5. THE Reminder_Cron SHALL be scheduled to run hourly so that both the 24-hour and 2-hour Reminder_Windows are checked at least once per hour.
+
+---
+
+### Requirement 5: SMS Message Content for Contribution Reminders
+
+**User Story:** As a circle member, I want the reminder SMS to clearly state what action I need to take and how much time I have, so that I can act quickly.
+
+#### Acceptance Criteria
+
+1. THE SMS_Notification_System SHALL provide a `sendContributionReminderSms` function that accepts a phone number, circle name, contribution amount in USDC, and hours remaining.
+2. WHEN `sendContributionReminderSms` is called, THE SMS_Notification_System SHALL send a message that contains the circle name, the contribution amount, and the hours remaining until the deadline.
+3. THE SMS_Notification_System SHALL prefix all contribution reminder messages with "Ajosave:" to maintain consistency with existing notification messages.
+
+---
+
+### Requirement 6: Idempotency and Duplicate Prevention
+
+**User Story:** As a circle member, I want to receive at most one reminder per reminder window per cycle, so that I am not spammed with repeated messages.
+
+#### Acceptance Criteria
+
+1. WHEN the Contribution_Reminder_Service processes a circle in the 24-hour Reminder_Window, THE Contribution_Reminder_Service SHALL send at most one 24-hour reminder SMS per Pending_Contributor per cycle.
+2. WHEN the Contribution_Reminder_Service processes a circle in the 2-hour Reminder_Window, THE Contribution_Reminder_Service SHALL send at most one 2-hour reminder SMS per Pending_Contributor per cycle.
+3. WHILE a circle's `next_payout_at` remains within a Reminder_Window across multiple hourly cron runs, THE Contribution_Reminder_Service SHALL NOT send duplicate reminders to the same Pending_Contributor for the same window and cycle.
+
+---
+
+### Requirement 7: Graceful Handling of Circles Without a Deadline
+
+**User Story:** As a system operator, I want the reminder cron to safely skip circles that have no scheduled deadline, so that the cron does not produce errors for circles in non-active states.
+
+#### Acceptance Criteria
+
+1. WHEN the Contribution_Reminder_Service queries for circles, THE Contribution_Reminder_Service SHALL only consider circles where `next_payout_at IS NOT NULL`.
+2. IF a circle has `status != 'active'`, THEN THE Contribution_Reminder_Service SHALL exclude that circle from reminder processing.
+3. IF an error occurs while processing reminders for a single circle, THEN THE Contribution_Reminder_Service SHALL log the error and continue processing remaining circles without aborting the entire run.

--- a/.kiro/specs/contribution-reminders/tasks.md
+++ b/.kiro/specs/contribution-reminders/tasks.md
@@ -1,0 +1,147 @@
+# Implementation Plan: Contribution Reminders
+
+## Overview
+
+Implement automated SMS reminders for active circle members who have not yet confirmed their contribution before the cycle deadline. The feature adds a new `contribution_reminders` idempotency table, extends the SMS and notification layers, adds a new scheduler function with 24h/2h window logic, and exposes a new cron endpoint — all following existing patterns in the codebase.
+
+## Tasks
+
+- [x] 1. Create the `contribution_reminders` migration
+  - Create `migrations/1746100000000_add-contribution-reminders-table.ts` using `node-pg-migrate` following the pattern of `migrations/1745505605000_initial-schema.ts`
+  - Define the `contribution_reminders` table with columns: `id` (UUID PK), `member_id` (UUID FK → `members.id` ON DELETE CASCADE), `cycle_number` (INTEGER, CHECK > 0), `reminder_type` (VARCHAR(4), CHECK IN ('24h','2h')), `sent_at` (TIMESTAMP DEFAULT NOW())
+  - Add `UNIQUE (member_id, cycle_number, reminder_type)` constraint — this is the idempotency guarantee
+  - Add index `idx_contribution_reminders_member` on `(member_id, cycle_number)`
+  - Implement `down()` to drop the table
+  - _Requirements: 6.1, 6.2, 6.3_
+
+- [x] 2. Add `sendContributionReminderSms` to the SMS layer
+  - [x] 2.1 Implement `sendContributionReminderSms` in `src/lib/sms.ts`
+    - Add the function after the existing `sendMissedContributionSms` function, following the same pattern as `sendPayoutReminderSms`
+    - Message format: `Ajosave: Your contribution of <amount> USDC to "<circleName>" is due in <hoursLeft> hours. Please contribute now to avoid being marked as defaulted!`
+    - Signature: `sendContributionReminderSms(phone: string, circleName: string, amount: string, hoursLeft: number): Promise<void>`
+    - _Requirements: 5.1, 5.2, 5.3_
+
+  - [ ]* 2.2 Write property test for SMS message content (Property 3)
+    - **Property 3: SMS message content**
+    - Generate arbitrary circle names (including special characters, Unicode), amounts, and hours values (24 or 2) using `fast-check`
+    - Mock `sendSms` and capture the message argument
+    - Assert the captured message contains the circle name, the amount, the hours value, and starts with "Ajosave:"
+    - Tag: `// Feature: contribution-reminders, Property 3: SMS message content`
+    - **Validates: Requirements 2.2, 3.2, 5.2, 5.3**
+
+- [x] 3. Add `notifyContributionReminder` to the notification service
+  - [x] 3.1 Implement `notifyContributionReminder` in `src/server/services/notification.service.ts`
+    - Add the import for `sendContributionReminderSms` from `@/lib/sms`
+    - Follow the exact pattern of `notifyPayoutReminder`: call `canSendSms`, then `getUserPhone`, then `sendContributionReminderSms` inside a try/catch that logs but does not throw
+    - Signature: `notifyContributionReminder(userId: string, circleName: string, amount: string, hoursLeft: number): Promise<void>`
+    - _Requirements: 2.1, 2.3, 2.4, 3.1, 3.3, 3.4_
+
+  - [ ]* 3.2 Write unit tests for `notifyContributionReminder`
+    - Test: skips sending when `sms_notifications_enabled = false`
+    - Test: skips sending when user has no phone number
+    - Test: catches and logs SMS errors without throwing
+    - Test: calls `sendContributionReminderSms` with correct arguments when user is eligible
+    - Mock `@/lib/db` and `@/lib/sms` following the pattern in `src/app/api/circles/[id]/contribute/__tests__/route.test.ts`
+    - _Requirements: 2.3, 2.4, 3.3, 3.4_
+
+  - [ ]* 3.3 Write property test for opt-out enforcement (Property 4)
+    - **Property 4: Opt-out is always respected**
+    - Generate arbitrary `userId` strings with `sms_notifications_enabled = false` mocked in the DB
+    - Call `notifyContributionReminder` for each generated user
+    - Assert `sendContributionReminderSms` (and the underlying `sendSms`) is never called
+    - Tag: `// Feature: contribution-reminders, Property 4: Opt-out is always respected`
+    - **Validates: Requirements 2.3, 3.3**
+
+- [x] 4. Implement `sendContributionReminders` in the scheduler service
+  - [x] 4.1 Implement the core `sendContributionReminders` function in `src/server/services/scheduler.service.ts`
+    - Add the function after `processMissedContributions`, importing `notifyContributionReminder` from `./notification.service`
+    - Define `WINDOWS` constant: `[{ hoursLeft: 24, lowerBound: '23 hours', upperBound: '25 hours' }, { hoursLeft: 2, lowerBound: '1 hour', upperBound: '3 hours' }]`
+    - For each window, query circles: `status = 'active' AND next_payout_at IS NOT NULL AND next_payout_at > NOW() + INTERVAL '<lower>' AND next_payout_at < NOW() + INTERVAL '<upper>'`
+    - For each circle, query active members (`status = 'active'`)
+    - For each member, check if they are a Pending_Contributor: no contribution record for `current_cycle`, or contribution with `status = 'pending'`
+    - Check idempotency: `SELECT 1 FROM contribution_reminders WHERE member_id = $1 AND cycle_number = $2 AND reminder_type = $3`
+    - If not already reminded: call `notifyContributionReminder`, then `INSERT INTO contribution_reminders (...) ON CONFLICT DO NOTHING`
+    - Wrap each circle's processing in try/catch — log errors and continue
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 2.1, 3.1, 6.1, 6.2, 6.3, 7.1, 7.2, 7.3_
+
+  - [ ]* 4.2 Write property test for circle window filtering (Property 1)
+    - **Property 1: Circle window filtering**
+    - Generate arbitrary arrays of circles with random `status` values and `next_payout_at` offsets using `fast-check`
+    - Extract and test the filtering predicate (active, non-null deadline, within window bounds) in isolation
+    - Assert the filtered result contains exactly the circles that satisfy all three conditions
+    - Tag: `// Feature: contribution-reminders, Property 1: Circle window filtering`
+    - **Validates: Requirements 1.1, 7.1, 7.2**
+
+  - [ ]* 4.3 Write property test for pending contributor classification (Property 2)
+    - **Property 2: Pending contributor classification**
+    - Generate arbitrary members paired with arbitrary contribution states: no record, `pending`, `confirmed`, `missed`
+    - Extract and test the classification predicate in isolation
+    - Assert a member is classified as Pending_Contributor if and only if they have no record or their record has `status = 'pending'`
+    - Tag: `// Feature: contribution-reminders, Property 2: Pending contributor classification`
+    - **Validates: Requirements 1.2, 1.3, 1.4, 1.5**
+
+  - [ ]* 4.4 Write property test for per-circle fault isolation (Property 5)
+    - **Property 5: Per-circle fault isolation**
+    - Generate an arbitrary list of mock circles where a random subset throws during processing
+    - Mock `@/lib/db` so the failing circles throw and the passing circles resolve normally
+    - Call `sendContributionReminders` and assert it resolves without throwing
+    - Assert that non-failing circles were processed (their `notifyContributionReminder` was called)
+    - Tag: `// Feature: contribution-reminders, Property 5: Per-circle fault isolation`
+    - **Validates: Requirements 2.4, 3.4, 7.3**
+
+  - [ ]* 4.5 Write property test for idempotency (Property 6)
+    - **Property 6: Idempotency — at most one reminder per window per cycle**
+    - Generate an arbitrary Pending_Contributor and simulate N ≥ 2 invocations of `sendContributionReminders` for the same circle/cycle/window
+    - Use an in-memory set to simulate the `contribution_reminders` unique constraint (first INSERT succeeds, subsequent ones are no-ops)
+    - Assert `sendContributionReminderSms` is called exactly once across all N invocations
+    - Tag: `// Feature: contribution-reminders, Property 6: Idempotency — at most one reminder per window per cycle`
+    - **Validates: Requirements 6.1, 6.2, 6.3**
+
+- [x] 5. Checkpoint — Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 6. Create the cron endpoint
+  - [x] 6.1 Create `src/app/api/cron/contribution-reminders/route.ts`
+    - Mirror the structure of `src/app/api/cron/reminders/route.ts` exactly
+    - Import `sendContributionReminders` from `@/server/services/scheduler.service`
+    - Import `verifyCronSecret` from `@/lib/cron-auth`
+    - `GET` handler: call `verifyCronSecret(req)`, return 401 if invalid; call `sendContributionReminders()` in try/catch; return `200 { success: true, message: "Contribution reminders sent successfully" }` on success; return `500 { success: false, error: message }` on error
+    - _Requirements: 4.1, 4.2, 4.3, 4.4_
+
+  - [ ]* 6.2 Write unit tests for the cron endpoint
+    - Test: returns 401 when `Authorization` header is missing
+    - Test: returns 401 when token is wrong
+    - Test: returns 200 with `{ success: true }` when auth is valid and service succeeds
+    - Test: returns 500 with `{ success: false, error: ... }` when service throws
+    - Mock `@/lib/cron-auth` and `@/server/services/scheduler.service`
+    - Follow the `@jest-environment node` pattern from existing test files
+    - _Requirements: 4.2, 4.3, 4.4_
+
+  - [ ]* 6.3 Write property test for unauthorized request rejection (Property 7)
+    - **Property 7: Unauthorized requests are always rejected**
+    - Generate arbitrary strings as `Authorization` header values (excluding the exact valid secret) using `fast-check`
+    - Call the `GET` handler with each generated header value
+    - Assert all return 401 and that `sendContributionReminders` is never called
+    - Tag: `// Feature: contribution-reminders, Property 7: Unauthorized requests are always rejected`
+    - **Validates: Requirements 4.3**
+
+- [x] 7. Update `docs/sms-notifications.md`
+  - Add a new "Contribution Reminder" section under "Notification Types" documenting:
+    - Trigger: hourly cron, 24h and 2h before `next_payout_at`
+    - Recipients: active members with no confirmed contribution for the current cycle
+    - Frequency: at most once per reminder window per cycle (idempotent)
+    - Example messages for both the 24h and 2h variants
+  - Add the new `/api/cron/contribution-reminders` endpoint to the "Cron Jobs" section with its hourly schedule
+  - Add the new endpoint to the Vercel Cron and GitHub Actions configuration examples
+  - _Requirements: 4.5_
+
+- [x] 8. Final checkpoint — Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Property tests use `fast-check` (already a transitive dependency); each is tagged with `// Feature: contribution-reminders, Property N: ...`
+- The `UNIQUE (member_id, cycle_number, reminder_type)` constraint in the migration is the primary idempotency mechanism — `ON CONFLICT DO NOTHING` in the scheduler relies on it
+- All new code is additive; no existing functions are modified

--- a/.kiro/specs/freighter-wallet/.config.kiro
+++ b/.kiro/specs/freighter-wallet/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "6f502639-a32f-4049-8dbc-5b8b97545719", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/freighter-wallet/design.md
+++ b/.kiro/specs/freighter-wallet/design.md
@@ -1,0 +1,417 @@
+# Design Document: Freighter Wallet Integration
+
+## Overview
+
+This feature integrates the `@stellar/freighter-api` browser extension wallet into AjoSave so that users can connect their Freighter wallet and have their Stellar public key auto-populated in the Edit Profile form and the Join Circle form. Users without Freighter installed retain the existing manual text-entry experience unchanged.
+
+The integration is entirely client-side. No backend changes are required. A shared custom hook (`useFreighterWallet`) encapsulates all Freighter API interactions, and a shared `ConnectWalletButton` component renders the appropriate UI based on connection state. Both the Profile page and the Join Circle form consume the hook and component independently, with no shared global state between instances.
+
+### Key Design Decisions
+
+- **Hook-per-instance isolation**: Each form mounts its own `useFreighterWallet` instance. This avoids cross-form state contamination and keeps the hook stateless at the module level.
+- **`requestAccess` as the connect entry point**: The Freighter API's `requestAccess()` both prompts for permission and returns the public key in one call, making it the right choice for the connect flow. `isConnected()` is used only for the mount-time detection check.
+- **Network validation via `getNetwork()`**: After `requestAccess()` succeeds, the hook calls `getNetwork()` to verify the user is on the expected network (Pubnet/PUBLIC) before accepting the key.
+- **No `@stellar/stellar-sdk` for wallet connectivity**: The SDK is already installed for other purposes; the hook imports exclusively from `@stellar/freighter-api`.
+- **Pinned exact version**: `@stellar/freighter-api` is pinned to `3.1.0` (the latest stable release compatible with the v6 API surface documented at docs.freighter.app) to ensure reproducible builds.
+
+---
+
+## Architecture
+
+The feature adds three new files and modifies two existing ones:
+
+```
+src/
+  hooks/
+    useFreighterWallet.ts          ← new: shared hook
+  components/
+    wallet/
+      ConnectWalletButton.tsx      ← new: shared button component
+      ConnectWalletButton.module.css ← new: styles
+  app/
+    profile/
+      page.tsx                     ← modified: wire up hook + button
+  components/
+    circle/
+      JoinCircleForm.tsx           ← modified: wire up hook + button
+```
+
+### Data Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Form (Profile or Join)
+    participant useFreighterWallet
+    participant ConnectWalletButton
+    participant @stellar/freighter-api
+
+    Form->>useFreighterWallet: mount → detect()
+    useFreighterWallet->@stellar/freighter-api: isConnected()
+    @stellar/freighter-api-->>useFreighterWallet: { isConnected: true/false }
+    useFreighterWallet-->>Form: connectionState = 'disconnected' | 'not_installed'
+
+    User->>ConnectWalletButton: click "Connect Wallet"
+    ConnectWalletButton->>useFreighterWallet: connect()
+    useFreighterWallet-->>Form: connectionState = 'connecting'
+    useFreighterWallet->@stellar/freighter-api: requestAccess()
+    @stellar/freighter-api-->>useFreighterWallet: { address } | { error }
+    useFreighterWallet->@stellar/freighter-api: getNetwork()
+    @stellar/freighter-api-->>useFreighterWallet: { network }
+    useFreighterWallet-->>Form: connectionState = 'connected', publicKey = address
+    Form-->>Form: setForm({ stellarPublicKey: publicKey })
+```
+
+### Connection State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> not_installed : isConnected() = false
+    [*] --> disconnected : isConnected() = true
+    disconnected --> connecting : connect() called
+    connecting --> connected : valid key + correct network
+    connecting --> disconnected : user rejected / locked / invalid key / network mismatch
+    connected --> disconnected : disconnect() called
+```
+
+---
+
+## Components and Interfaces
+
+### `useFreighterWallet` Hook
+
+**File**: `src/hooks/useFreighterWallet.ts`
+
+```typescript
+export type ConnectionState =
+  | "not_installed"
+  | "disconnected"
+  | "connecting"
+  | "connected";
+
+export interface UseFreighterWalletReturn {
+  connectionState: ConnectionState;
+  publicKey: string | null;
+  error: string | null;
+  connect: () => Promise<void>;
+  disconnect: () => void;
+}
+
+export function useFreighterWallet(): UseFreighterWalletReturn
+```
+
+**Behaviour contract**:
+
+- On mount, calls `isConnected()` from `@stellar/freighter-api`. If it resolves `{ isConnected: true }`, sets state to `disconnected`. If `{ isConnected: false }` or the call throws, sets state to `not_installed` (and logs the error).
+- `connect()`:
+  1. Sets `connectionState` to `connecting`, clears `error`.
+  2. Calls `requestAccess()`. On error, maps the error string to a user-facing message and sets `connectionState` to `disconnected`.
+  3. Validates the returned `address`: must be exactly 56 characters and start with `G`. On failure, sets error and `connectionState` to `disconnected`.
+  4. Calls `getNetwork()`. If the returned `network` is not `"PUBLIC"`, sets a network-mismatch error and `connectionState` to `disconnected`.
+  5. On success, sets `publicKey` and `connectionState` to `connected`.
+- `disconnect()`: Sets `connectionState` to `disconnected`, `publicKey` to `null`, `error` to `null`.
+
+**Error message mapping**:
+
+| Condition | Error message |
+|---|---|
+| User rejected prompt | `"Connection request was rejected. You can enter your Stellar key manually."` |
+| Wallet locked | `"Your Freighter wallet is locked. Please unlock it and try again."` |
+| Invalid public key | `"The key returned by Freighter is not a valid Stellar public key."` |
+| Network mismatch | `"Freighter is connected to {detectedNetwork}, but this app requires Pubnet. Please switch networks in Freighter and try again."` |
+
+**Error detection**: The Freighter API returns errors as a string in the `error` field of the response object. Rejection is detected by checking if the error string contains `"rejected"` or `"denied"` (case-insensitive). Locked wallet is detected by checking for `"locked"`.
+
+---
+
+### `ConnectWalletButton` Component
+
+**File**: `src/components/wallet/ConnectWalletButton.tsx`
+
+```typescript
+interface ConnectWalletButtonProps {
+  connectionState: ConnectionState;
+  onConnect: () => void;
+  onDisconnect: () => void;
+  publicKey: string | null;
+}
+
+export function ConnectWalletButton(props: ConnectWalletButtonProps): JSX.Element
+```
+
+**Rendering rules by state**:
+
+| `connectionState` | Renders |
+|---|---|
+| `not_installed` | Nothing (null) — the parent renders the install link |
+| `disconnected` | "Connect Freighter Wallet" button (enabled) |
+| `connecting` | "Connect Freighter Wallet" button (disabled, `aria-busy="true"`, `aria-disabled="true"`, spinner) |
+| `connected` | "Disconnect" button + truncated key status (`role="status"`) |
+
+The "Connect Freighter Wallet" button has `aria-label="Connect Freighter Wallet"` as its accessible name. The "Disconnect" button has `aria-label="Disconnect Freighter Wallet"`.
+
+When `connected`, the status message reads: `"Connected: {first8}…{last4}"` where `first8` is `publicKey.slice(0, 8)` and `last4` is `publicKey.slice(-4)`.
+
+---
+
+### Profile Page Integration
+
+**File**: `src/app/profile/page.tsx` (modified)
+
+The existing `stellarPublicKey` input group is augmented:
+
+1. `useFreighterWallet()` is called at the top of the component.
+2. A `useEffect` watches `publicKey` from the hook: when it becomes non-null, it calls `setForm(f => ({ ...f, stellarPublicKey: publicKey }))`.
+3. A second `useEffect` watches `disconnect`: when `connectionState` transitions to `disconnected` from `connected`, it clears the field (sets `stellarPublicKey` to `""`).
+4. The `stellarPublicKey` input group renders:
+   - The existing `<input>` (always present, always editable).
+   - `<ConnectWalletButton>` (rendered when `connectionState !== 'not_installed'`).
+   - Install helper text with link to `https://freighter.app` (rendered when `connectionState === 'not_installed'`).
+   - Error message in `role="alert"` (rendered when `error` is non-null).
+
+---
+
+### Join Circle Form Integration
+
+**File**: `src/components/circle/JoinCircleForm.tsx` (modified)
+
+Same pattern as the Profile page:
+
+1. `useFreighterWallet()` called at the top.
+2. `useEffect` syncs `publicKey` → `setStellarPublicKey(publicKey)`.
+3. `useEffect` clears field on disconnect.
+4. The `stellarPublicKey` field group renders the same set of sub-elements as the Profile page.
+
+---
+
+## Data Models
+
+### Connection State
+
+```typescript
+type ConnectionState = "not_installed" | "disconnected" | "connecting" | "connected";
+```
+
+### Hook Internal State
+
+```typescript
+interface WalletState {
+  connectionState: ConnectionState;
+  publicKey: string | null;
+  error: string | null;
+}
+```
+
+### Freighter API Response Types (from `@stellar/freighter-api`)
+
+```typescript
+// isConnected()
+type IsConnectedResult = { isConnected: boolean } & { error?: string };
+
+// requestAccess()
+type RequestAccessResult = { address: string } & { error?: string };
+
+// getNetwork()
+type GetNetworkResult = { network: string; networkPassphrase: string } & { error?: string };
+```
+
+### Public Key Validation Rule
+
+A Stellar public key is valid for this feature if and only if:
+- `typeof key === 'string'`
+- `key.length === 56`
+- `key.startsWith('G')`
+
+This matches the validation already used in `src/types/schemas.ts` (`z.string().length(56)`), extended with the `G` prefix check.
+
+### Expected Network
+
+The application expects `network === "PUBLIC"` (Pubnet). This value is compared case-insensitively against the string returned by `getNetwork()`.
+
+---
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+This feature involves React hook logic with clear input/output behavior (key validation, state transitions, error message formatting) that is well-suited to property-based testing. The project uses Jest + `@testing-library/react`; the property-based testing library **fast-check** will be added as a dev dependency to implement these properties.
+
+---
+
+### Property 1: Valid public keys are always accepted
+
+*For any* string that is exactly 56 characters long and begins with `G`, when `requestAccess()` is mocked to return that string as the address and `getNetwork()` returns `"PUBLIC"`, the hook SHALL set `connectionState` to `"connected"` and `publicKey` to that string.
+
+**Validates: Requirements 4.5, 2.5, 3.4**
+
+---
+
+### Property 2: Invalid public keys are always rejected
+
+*For any* string that either is not exactly 56 characters long or does not begin with `G`, when `requestAccess()` is mocked to return that string as the address, the hook SHALL set `connectionState` to `"disconnected"` and set a non-null `error`.
+
+**Validates: Requirements 4.5, 4.6**
+
+---
+
+### Property 3: Network mismatch error names both networks
+
+*For any* network name string that is not `"PUBLIC"` (case-insensitive), when `getNetwork()` returns that network name after a successful `requestAccess()`, the hook SHALL set `connectionState` to `"disconnected"` and the `error` string SHALL contain both the detected network name and the word `"Pubnet"`.
+
+**Validates: Requirements 7.1, 7.2**
+
+---
+
+### Property 4: Error messages always appear in a role="alert" element
+
+*For any* non-empty error string set on the hook, when `ConnectWalletButton` or the parent form renders with that error, the error text SHALL appear inside a DOM element with `role="alert"`.
+
+**Validates: Requirements 9.3**
+
+---
+
+### Property 5: Connected status always shows correct key truncation
+
+*For any* valid Stellar public key (56 chars, starts with `G`), when the hook is in `"connected"` state with that key, the rendered status message SHALL contain the first 8 characters of the key and the last 4 characters of the key.
+
+**Validates: Requirements 9.4**
+
+---
+
+## Error Handling
+
+### Freighter Not Installed
+
+Detected at mount via `isConnected()` returning `{ isConnected: false }` or throwing. The hook sets `connectionState` to `not_installed`. The UI renders the manual input with an install link. No error message is shown — the install link is informational, not an error.
+
+### User Rejects Permission Prompt
+
+`requestAccess()` returns `{ error: "..." }` where the error string contains `"rejected"` or `"denied"`. The hook maps this to the rejection message and sets `connectionState` to `disconnected`. The Connect button re-enables. Calling `connect()` again clears the error before retrying.
+
+### Wallet Locked
+
+`requestAccess()` returns an error containing `"locked"`. The hook maps this to the locked-wallet message and sets `connectionState` to `disconnected`.
+
+### Invalid Public Key
+
+After `requestAccess()` succeeds, the returned `address` fails the 56-char / `G`-prefix validation. The hook sets an error and `connectionState` to `disconnected`. The raw invalid key is never written to the form field.
+
+### Network Mismatch
+
+After `requestAccess()` succeeds and key validation passes, `getNetwork()` returns a network other than `"PUBLIC"`. The hook sets the mismatch error (naming both networks) and `connectionState` to `disconnected`. The key is not written to the form field.
+
+### Unexpected Errors
+
+Any unhandled exception in `connect()` is caught, logged to `console.error`, and results in a generic error message: `"An unexpected error occurred. Please try again."` with `connectionState` set to `disconnected`.
+
+### SSR Safety
+
+`@stellar/freighter-api` accesses `window` and browser extension APIs. The hook must guard against SSR by checking `typeof window !== 'undefined'` before calling any Freighter API function. In Next.js 14, the hook is only used in `"use client"` components, but the guard is included defensively.
+
+---
+
+## Testing Strategy
+
+The project uses Jest 29 + `@testing-library/react` 16. **fast-check** will be added as a dev dependency for property-based tests.
+
+### Unit Tests — `useFreighterWallet` Hook
+
+Test file: `src/hooks/__tests__/useFreighterWallet.test.ts`
+
+All Freighter API functions are mocked via `jest.mock('@stellar/freighter-api')`.
+
+**Example-based tests** (one test per scenario):
+- Mount with `isConnected()` → `true`: state becomes `disconnected`
+- Mount with `isConnected()` → `false`: state becomes `not_installed`
+- Mount with `isConnected()` throwing: state becomes `not_installed`, `console.error` called
+- `connect()` transitions through `connecting` → `connected` on success
+- `connect()` on rejection: state → `disconnected`, correct error message
+- `connect()` on locked wallet: state → `disconnected`, correct error message
+- `connect()` on network mismatch: state → `disconnected`, error names both networks
+- `disconnect()` resets state and publicKey to null
+- Two hook instances are independent (no shared state)
+- Calling `connect()` after rejection clears the previous error
+
+**Property-based tests** (fast-check, minimum 100 iterations each):
+
+```
+// Feature: freighter-wallet, Property 1: Valid public keys are always accepted
+fc.assert(fc.property(
+  fc.string({ minLength: 55, maxLength: 55 }).map(s => 'G' + s),
+  async (validKey) => { ... }
+))
+
+// Feature: freighter-wallet, Property 2: Invalid public keys are always rejected
+fc.assert(fc.property(
+  fc.oneof(
+    fc.string().filter(s => s.length !== 56),
+    fc.string({ minLength: 56, maxLength: 56 }).filter(s => !s.startsWith('G'))
+  ),
+  async (invalidKey) => { ... }
+))
+
+// Feature: freighter-wallet, Property 3: Network mismatch error names both networks
+fc.assert(fc.property(
+  fc.string().filter(s => s.toUpperCase() !== 'PUBLIC'),
+  async (network) => { ... }
+))
+```
+
+### Unit Tests — `ConnectWalletButton` Component
+
+Test file: `src/components/wallet/__tests__/ConnectWalletButton.test.tsx`
+
+**Example-based tests**:
+- Renders nothing when `connectionState === 'not_installed'`
+- Renders enabled button with accessible name "Connect Freighter Wallet" when `disconnected`
+- Renders disabled button with `aria-busy="true"` and `aria-disabled="true"` when `connecting`
+- Renders "Disconnect" button and status message when `connected`
+- Calls `onConnect` when Connect button is clicked
+- Calls `onDisconnect` when Disconnect button is clicked
+- Connect and Disconnect buttons are keyboard-operable (respond to Enter/Space)
+
+**Property-based tests**:
+
+```
+// Feature: freighter-wallet, Property 4: Error messages always appear in a role="alert" element
+fc.assert(fc.property(
+  fc.string({ minLength: 1 }),
+  (errorMessage) => { ... }
+))
+
+// Feature: freighter-wallet, Property 5: Connected status always shows correct key truncation
+fc.assert(fc.property(
+  fc.string({ minLength: 55, maxLength: 55 }).map(s => 'G' + s),
+  (validKey) => { ... }
+))
+```
+
+### Integration Tests — Profile Page
+
+Test file: `src/app/profile/__tests__/page.test.tsx`
+
+Mocks: `useFreighterWallet` hook, `next-auth/react`, `next/navigation`, `fetch`.
+
+- When hook returns `not_installed`: no Connect button, install link present
+- When hook returns `disconnected`: Connect button present alongside input
+- When hook returns `connected` with a key: input value equals the key, Disconnect control present
+- Connecting auto-populates the `stellarPublicKey` input
+- Disconnecting clears the `stellarPublicKey` input
+- Error from hook renders in `role="alert"` element
+- Form submits with the wallet-provided key unchanged
+
+### Integration Tests — Join Circle Form
+
+Test file: `src/components/circle/__tests__/JoinCircleForm.test.tsx`
+
+Same scenarios as Profile page integration tests, adapted for the Join Circle form context.
+
+### Accessibility Tests
+
+Covered within the component unit tests using `@testing-library/react`'s accessibility queries (`getByRole`, `getByLabelText`). No separate accessibility test file is needed.
+
+### What Is Not Tested
+
+- Actual Freighter browser extension behaviour (tested by the Freighter team)
+- The `npm install` step (verified by CI build)
+- Visual appearance and CSS (out of scope for unit tests)

--- a/.kiro/specs/freighter-wallet/requirements.md
+++ b/.kiro/specs/freighter-wallet/requirements.md
@@ -1,0 +1,159 @@
+# Requirements Document
+
+## Introduction
+
+AjoSave users currently enter their Stellar public key by hand in two places: the Edit Profile form (`src/app/profile/page.tsx`) and the Join Circle form (`src/components/circle/JoinCircleForm.tsx`). Manual entry is error-prone and creates friction for users who already manage their Stellar identity through the Freighter browser extension wallet.
+
+This feature integrates the `@stellar/freighter-api` SDK to let users connect their Freighter wallet and have their Stellar public key auto-populated in both forms. Users who do not have Freighter installed retain the existing manual text-entry experience unchanged.
+
+## Glossary
+
+- **Freighter**: A Stellar-network browser extension wallet that exposes a JavaScript API for requesting account access.
+- **Freighter_API**: The `@stellar/freighter-api` npm package (`@stellar/freighter-api`) used to communicate with the Freighter extension.
+- **Connect_Button**: The "Connect Wallet" UI control that initiates the Freighter connection flow.
+- **Public_Key**: A 56-character Stellar account address beginning with `G`, used to receive payouts.
+- **Profile_Form**: The Edit Profile form on `src/app/profile/page.tsx` that contains the `stellarPublicKey` field.
+- **Join_Form**: The Join Circle form in `src/components/circle/JoinCircleForm.tsx` that contains the `stellarPublicKey` field.
+- **Wallet_Hook**: A shared React custom hook (`useFreighterWallet`) that encapsulates all Freighter_API interactions.
+- **Connection_State**: One of four states the wallet integration can be in: `not_installed`, `disconnected`, `connecting`, or `connected`.
+- **Network_Mismatch**: The condition where Freighter is connected to a Stellar network (e.g., testnet) that differs from the network the application expects (e.g., mainnet/pubnet).
+
+---
+
+## Requirements
+
+### Requirement 1: Freighter Installation Detection
+
+**User Story:** As a user visiting any page with a Stellar public key field, I want the UI to know whether Freighter is installed, so that I am shown the appropriate input experience without having to do anything.
+
+#### Acceptance Criteria
+
+1. WHEN the Profile_Form or Join_Form mounts, THE Wallet_Hook SHALL check whether the Freighter extension is present in the browser environment.
+2. WHEN Freighter is detected as installed, THE Wallet_Hook SHALL set the Connection_State to `disconnected`.
+3. WHEN Freighter is not detected, THE Wallet_Hook SHALL set the Connection_State to `not_installed`.
+4. THE Wallet_Hook SHALL complete the installation check within 500 ms of component mount.
+5. IF the installation check throws an unexpected error, THEN THE Wallet_Hook SHALL set the Connection_State to `not_installed` and log the error to the console.
+
+---
+
+### Requirement 2: Connect Wallet Button — Profile Form
+
+**User Story:** As a user on the Profile page who has Freighter installed, I want a "Connect Wallet" button next to the Stellar Public Key field, so that I can populate my key automatically without typing it.
+
+#### Acceptance Criteria
+
+1. WHILE the Connection_State is `disconnected`, THE Profile_Form SHALL render the Connect_Button alongside the `stellarPublicKey` text input.
+2. WHILE the Connection_State is `not_installed`, THE Profile_Form SHALL render only the `stellarPublicKey` text input with a helper text link directing the user to install Freighter.
+3. WHEN the user activates the Connect_Button, THE Wallet_Hook SHALL set the Connection_State to `connecting` and request account access from Freighter_API.
+4. WHILE the Connection_State is `connecting`, THE Connect_Button SHALL be disabled and display a loading indicator.
+5. WHEN Freighter_API returns a valid Public_Key, THE Wallet_Hook SHALL set the Connection_State to `connected` and populate the `stellarPublicKey` form field with the returned Public_Key.
+6. WHILE the Connection_State is `connected`, THE Profile_Form SHALL display the connected Public_Key in the `stellarPublicKey` field and replace the Connect_Button with a "Disconnect" control.
+7. WHEN the user activates the "Disconnect" control, THE Wallet_Hook SHALL set the Connection_State to `disconnected` and clear the `stellarPublicKey` form field.
+8. WHILE the Connection_State is `connected`, THE Profile_Form SHALL allow the user to edit the `stellarPublicKey` field manually to override the wallet-provided value.
+
+---
+
+### Requirement 3: Connect Wallet Button — Join Circle Form
+
+**User Story:** As a user joining a circle who has Freighter installed, I want the same "Connect Wallet" affordance in the Join Circle form, so that I do not have to copy-paste my Stellar key.
+
+#### Acceptance Criteria
+
+1. WHILE the Connection_State is `disconnected`, THE Join_Form SHALL render the Connect_Button alongside the `stellarPublicKey` text input.
+2. WHILE the Connection_State is `not_installed`, THE Join_Form SHALL render only the `stellarPublicKey` text input with a helper text link directing the user to install Freighter.
+3. WHEN the user activates the Connect_Button in the Join_Form, THE Wallet_Hook SHALL set the Connection_State to `connecting` and request account access from Freighter_API.
+4. WHEN Freighter_API returns a valid Public_Key, THE Wallet_Hook SHALL populate the `stellarPublicKey` field in the Join_Form with the returned Public_Key.
+5. WHILE the Connection_State is `connected`, THE Join_Form SHALL allow the user to edit the `stellarPublicKey` field manually to override the wallet-provided value.
+6. WHILE the Connection_State is `connected`, THE Join_Form SHALL display a "Disconnect" control that, when activated, clears the `stellarPublicKey` field and returns the Connection_State to `disconnected`.
+
+---
+
+### Requirement 4: Shared Wallet Hook
+
+**User Story:** As a developer, I want a single reusable hook that encapsulates all Freighter interactions, so that both the Profile_Form and Join_Form share consistent behaviour without duplicating logic.
+
+#### Acceptance Criteria
+
+1. THE Wallet_Hook SHALL expose the current Connection_State, the retrieved Public_Key (or `null`), a `connect` function, a `disconnect` function, and an `error` field.
+2. WHEN the `connect` function is called, THE Wallet_Hook SHALL invoke `Freighter_API.requestAccess` and update Connection_State accordingly.
+3. WHEN the `disconnect` function is called, THE Wallet_Hook SHALL set Connection_State to `disconnected` and set the Public_Key to `null`.
+4. THE Wallet_Hook SHALL be usable independently in both the Profile_Form and Join_Form without shared global state between instances.
+5. THE Wallet_Hook SHALL validate that the Public_Key returned by Freighter_API is exactly 56 characters and begins with `G` before setting it on the form field.
+6. IF the Public_Key returned by Freighter_API fails validation, THEN THE Wallet_Hook SHALL set an error message and set the Connection_State to `disconnected`.
+
+---
+
+### Requirement 5: Error Handling — User Rejects Connection
+
+**User Story:** As a user who declines the Freighter permission prompt, I want the form to return to its previous state with a clear message, so that I can choose to enter my key manually instead.
+
+#### Acceptance Criteria
+
+1. WHEN the user dismisses or rejects the Freighter permission prompt, THE Wallet_Hook SHALL set the Connection_State to `disconnected`.
+2. WHEN the user rejects the Freighter permission prompt, THE Wallet_Hook SHALL set an error message of "Connection request was rejected. You can enter your Stellar key manually."
+3. WHEN the Connection_State returns to `disconnected` after a rejection, THE Profile_Form and Join_Form SHALL display the error message and re-enable the Connect_Button.
+4. WHEN the user activates the Connect_Button again after a prior rejection, THE Wallet_Hook SHALL clear the previous error and retry the connection request.
+
+---
+
+### Requirement 6: Error Handling — Freighter Locked
+
+**User Story:** As a user whose Freighter wallet is installed but locked, I want a clear message telling me to unlock it, so that I know what action to take.
+
+#### Acceptance Criteria
+
+1. WHEN Freighter_API returns a locked-wallet error, THE Wallet_Hook SHALL set the Connection_State to `disconnected`.
+2. WHEN Freighter_API returns a locked-wallet error, THE Wallet_Hook SHALL set an error message of "Your Freighter wallet is locked. Please unlock it and try again."
+3. WHEN the Connection_State returns to `disconnected` after a locked-wallet error, THE Profile_Form and Join_Form SHALL display the error message and re-enable the Connect_Button.
+
+---
+
+### Requirement 7: Error Handling — Network Mismatch
+
+**User Story:** As a user whose Freighter is connected to the wrong Stellar network, I want a warning that explains the mismatch, so that I can switch networks before proceeding.
+
+#### Acceptance Criteria
+
+1. WHEN Freighter_API returns a Public_Key but the active network reported by Freighter_API does not match the application's expected network, THE Wallet_Hook SHALL set the Connection_State to `disconnected`.
+2. WHEN a Network_Mismatch is detected, THE Wallet_Hook SHALL set an error message that names both the detected network and the expected network (e.g., "Freighter is connected to Testnet, but this app requires Pubnet. Please switch networks in Freighter and try again.").
+3. WHEN a Network_Mismatch is detected, THE Profile_Form and Join_Form SHALL display the error message and re-enable the Connect_Button.
+
+---
+
+### Requirement 8: Graceful Fallback — Freighter Not Installed
+
+**User Story:** As a user who does not have Freighter installed, I want the Stellar public key field to work exactly as it does today, so that the new feature does not break my existing workflow.
+
+#### Acceptance Criteria
+
+1. WHILE the Connection_State is `not_installed`, THE Profile_Form SHALL render the `stellarPublicKey` text input in its current form without any Connect_Button.
+2. WHILE the Connection_State is `not_installed`, THE Join_Form SHALL render the `stellarPublicKey` text input in its current form without any Connect_Button.
+3. WHILE the Connection_State is `not_installed`, THE Profile_Form SHALL display helper text containing a link to the Freighter installation page (`https://freighter.app`).
+4. WHILE the Connection_State is `not_installed`, THE Join_Form SHALL display helper text containing a link to the Freighter installation page (`https://freighter.app`).
+5. THE Profile_Form and Join_Form SHALL submit the `stellarPublicKey` value to their respective API endpoints unchanged, regardless of whether the value was populated by Freighter or typed manually.
+
+---
+
+### Requirement 9: Accessibility
+
+**User Story:** As a user who relies on assistive technology, I want the Connect Wallet button and all wallet-related status messages to be accessible, so that I can use the feature with a screen reader or keyboard.
+
+#### Acceptance Criteria
+
+1. THE Connect_Button SHALL have an accessible name of "Connect Freighter Wallet".
+2. WHILE the Connection_State is `connecting`, THE Connect_Button SHALL have `aria-busy="true"` and `aria-disabled="true"`.
+3. WHEN an error message is set, THE Profile_Form and Join_Form SHALL render the error in an element with `role="alert"` so that screen readers announce it immediately.
+4. WHEN the Connection_State changes to `connected`, THE Profile_Form and Join_Form SHALL render a status message with `role="status"` confirming the wallet is connected and showing the first 8 and last 4 characters of the Public_Key.
+5. THE Connect_Button and "Disconnect" control SHALL be reachable and operable via keyboard navigation.
+
+---
+
+### Requirement 10: Package Installation
+
+**User Story:** As a developer setting up the feature, I want the Freighter API package added to the project dependencies, so that the integration can be built.
+
+#### Acceptance Criteria
+
+1. THE System SHALL add `@stellar/freighter-api` as a production dependency in `package.json`.
+2. THE System SHALL pin `@stellar/freighter-api` to an exact version to ensure reproducible builds.
+3. THE Wallet_Hook SHALL import exclusively from `@stellar/freighter-api` and SHALL NOT import from `@stellar/stellar-sdk` for wallet connectivity purposes.

--- a/.kiro/specs/freighter-wallet/tasks.md
+++ b/.kiro/specs/freighter-wallet/tasks.md
@@ -1,0 +1,122 @@
+# Implementation Plan: Freighter Wallet Integration
+
+## Overview
+
+Integrate `@stellar/freighter-api` into AjoSave so users can connect their Freighter browser extension wallet and have their Stellar public key auto-populated in the Edit Profile form and the Join Circle form. The implementation is entirely client-side: a shared hook (`useFreighterWallet`) encapsulates all Freighter API interactions, a shared `ConnectWalletButton` component renders the appropriate UI, and both forms are wired up independently.
+
+## Tasks
+
+- [x] 1. Install dependencies
+  - Add `@stellar/freighter-api@3.1.0` as a pinned production dependency in `package.json`
+  - Add `fast-check` as a dev dependency in `package.json`
+  - Run `npm install` to update `package-lock.json`
+  - _Requirements: 10.1, 10.2_
+
+- [x] 2. Create the `useFreighterWallet` shared hook
+  - [x] 2.1 Implement `useFreighterWallet` in `src/hooks/useFreighterWallet.ts`
+    - Export `ConnectionState` type: `"not_installed" | "disconnected" | "connecting" | "connected"`
+    - Export `UseFreighterWalletReturn` interface with `connectionState`, `publicKey`, `error`, `connect`, `disconnect`
+    - On mount: guard with `typeof window !== 'undefined'`, call `isConnected()` from `@stellar/freighter-api`; set state to `disconnected` if installed, `not_installed` if not (or if the call throws — log error to console)
+    - `connect()`: set state to `connecting` and clear `error`; call `requestAccess()`; validate key (56 chars, starts with `G`); call `getNetwork()` and verify `network === "PUBLIC"` (case-insensitive); set `connected` + `publicKey` on success
+    - Error mapping: rejection (`"rejected"` / `"denied"` in error string) → rejection message; locked (`"locked"`) → locked message; network mismatch → message naming both networks; invalid key → invalid key message; unexpected → generic message with `console.error`
+    - `disconnect()`: reset `connectionState` to `disconnected`, `publicKey` to `null`, `error` to `null`
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 5.1, 5.2, 6.1, 6.2, 7.1, 7.2, 10.3_
+
+  - [ ]* 2.2 Write property test — Property 1: Valid public keys are always accepted
+    - **Property 1: Valid public keys are always accepted**
+    - For any string that is exactly 56 characters and begins with `G`, when `requestAccess()` returns that string and `getNetwork()` returns `"PUBLIC"`, the hook SHALL set `connectionState` to `"connected"` and `publicKey` to that string
+    - Use `fc.string({ minLength: 55, maxLength: 55 }).map(s => 'G' + s)` as the generator
+    - **Validates: Requirements 4.5, 2.5, 3.4**
+
+  - [ ]* 2.3 Write property test — Property 2: Invalid public keys are always rejected
+    - **Property 2: Invalid public keys are always rejected**
+    - For any string that is not exactly 56 characters or does not begin with `G`, when `requestAccess()` returns that string, the hook SHALL set `connectionState` to `"disconnected"` and `error` to a non-null value
+    - Use `fc.oneof(fc.string().filter(s => s.length !== 56), fc.string({ minLength: 56, maxLength: 56 }).filter(s => !s.startsWith('G')))` as the generator
+    - **Validates: Requirements 4.5, 4.6**
+
+  - [ ]* 2.4 Write property test — Property 3: Network mismatch error names both networks
+    - **Property 3: Network mismatch error names both networks**
+    - For any network name string that is not `"PUBLIC"` (case-insensitive), when `getNetwork()` returns that name after a successful `requestAccess()`, the hook SHALL set `connectionState` to `"disconnected"` and the `error` string SHALL contain both the detected network name and the word `"Pubnet"`
+    - Use `fc.string().filter(s => s.toUpperCase() !== 'PUBLIC')` as the generator
+    - **Validates: Requirements 7.1, 7.2**
+
+  - [ ]* 2.5 Write example-based unit tests for `useFreighterWallet`
+    - Test file: `src/hooks/__tests__/useFreighterWallet.test.ts`
+    - Mock `@stellar/freighter-api` via `jest.mock`
+    - Cover: mount with `isConnected()` → true (state = `disconnected`); mount with `isConnected()` → false (state = `not_installed`); mount with `isConnected()` throwing (state = `not_installed`, `console.error` called); `connect()` transitions `connecting` → `connected`; rejection error message; locked-wallet error message; network mismatch error message; `disconnect()` resets state and `publicKey`; two instances are independent; calling `connect()` after rejection clears previous error
+    - _Requirements: 1.1, 1.2, 1.3, 4.1, 4.2, 4.3, 4.4, 5.1, 5.2, 5.4, 6.1, 6.2, 7.1, 7.2_
+
+- [x] 3. Create the `ConnectWalletButton` component
+  - [x] 3.1 Implement `ConnectWalletButton` in `src/components/wallet/ConnectWalletButton.tsx`
+    - Props: `{ connectionState: ConnectionState, onConnect: () => void, onDisconnect: () => void, publicKey: string | null }`
+    - `not_installed`: render `null`
+    - `disconnected`: render enabled button with `aria-label="Connect Freighter Wallet"`
+    - `connecting`: render disabled button with `aria-busy="true"` and `aria-disabled="true"` and a spinner element
+    - `connected`: render "Disconnect" button with `aria-label="Disconnect Freighter Wallet"` plus a `role="status"` element showing `"Connected: {publicKey.slice(0,8)}…{publicKey.slice(-4)}"`
+    - _Requirements: 2.1, 2.3, 2.4, 2.6, 2.7, 3.1, 3.3, 9.1, 9.2, 9.4, 9.5_
+
+  - [x] 3.2 Create `src/components/wallet/ConnectWalletButton.module.css`
+    - Add styles for the connect/disconnect button and the connected status message
+    - _Requirements: 2.1, 2.6_
+
+  - [ ]* 3.3 Write property test — Property 4: Error messages always appear in a `role="alert"` element
+    - **Property 4: Error messages always appear in a role="alert" element**
+    - For any non-empty error string, when the parent form renders with that error, the error text SHALL appear inside a DOM element with `role="alert"`
+    - Use `fc.string({ minLength: 1 })` as the generator
+    - Test file: `src/components/wallet/__tests__/ConnectWalletButton.test.tsx`
+    - **Validates: Requirements 9.3**
+
+  - [ ]* 3.4 Write property test — Property 5: Connected status always shows correct key truncation
+    - **Property 5: Connected status always shows correct key truncation**
+    - For any valid Stellar public key (56 chars, starts with `G`), when the hook is in `"connected"` state with that key, the rendered status message SHALL contain the first 8 characters and the last 4 characters of the key
+    - Use `fc.string({ minLength: 55, maxLength: 55 }).map(s => 'G' + s)` as the generator
+    - Test file: `src/components/wallet/__tests__/ConnectWalletButton.test.tsx`
+    - **Validates: Requirements 9.4**
+
+  - [ ]* 3.5 Write example-based unit tests for `ConnectWalletButton`
+    - Test file: `src/components/wallet/__tests__/ConnectWalletButton.test.tsx`
+    - Cover: renders nothing when `not_installed`; renders enabled button with accessible name when `disconnected`; renders disabled button with `aria-busy` and `aria-disabled` when `connecting`; renders Disconnect button and status message when `connected`; calls `onConnect` on click; calls `onDisconnect` on click; buttons are keyboard-operable
+    - _Requirements: 9.1, 9.2, 9.4, 9.5_
+
+- [x] 4. Checkpoint — Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 5. Integrate wallet into the Profile page
+  - [x] 5.1 Modify `src/app/profile/page.tsx` to wire up the hook and button
+    - Call `useFreighterWallet()` at the top of the component
+    - Add `useEffect` that watches `publicKey`: when non-null, call `setForm(f => ({ ...f, stellarPublicKey: publicKey }))`
+    - Add `useEffect` that watches `connectionState`: when it transitions to `"disconnected"`, clear `stellarPublicKey` to `""`
+    - In the `stellarPublicKey` input group: render `<ConnectWalletButton>` when `connectionState !== 'not_installed'`; render install helper text with link to `https://freighter.app` when `connectionState === 'not_installed'`; render error in a `role="alert"` element when `error` is non-null
+    - _Requirements: 1.1, 2.1, 2.2, 2.3, 2.5, 2.6, 2.7, 2.8, 5.3, 6.3, 7.3, 8.1, 8.3, 8.5, 9.3, 9.4_
+
+  - [ ]* 5.2 Write integration tests for the Profile page
+    - Test file: `src/app/profile/__tests__/page.test.tsx`
+    - Mock `useFreighterWallet`, `next-auth/react`, `next/navigation`, and `fetch`
+    - Cover: `not_installed` → no Connect button, install link present; `disconnected` → Connect button alongside input; `connected` with key → input value equals key, Disconnect control present; connecting auto-populates input; disconnecting clears input; error renders in `role="alert"`; form submits with wallet-provided key unchanged
+    - _Requirements: 2.1, 2.2, 2.5, 2.6, 2.7, 5.3, 8.1, 8.3, 8.5, 9.3_
+
+- [x] 6. Integrate wallet into the Join Circle form
+  - [x] 6.1 Modify `src/components/circle/JoinCircleForm.tsx` to wire up the hook and button
+    - Call `useFreighterWallet()` at the top of the component
+    - Add `useEffect` that watches `publicKey`: when non-null, call `setStellarPublicKey(publicKey)`
+    - Add `useEffect` that watches `connectionState`: when it transitions to `"disconnected"`, clear `stellarPublicKey` to `""`
+    - In the `stellarPublicKey` field group: render `<ConnectWalletButton>` when `connectionState !== 'not_installed'`; render install helper text with link to `https://freighter.app` when `connectionState === 'not_installed'`; render error in a `role="alert"` element when `error` is non-null
+    - _Requirements: 1.1, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 5.3, 6.3, 7.3, 8.2, 8.4, 8.5, 9.3, 9.4_
+
+  - [ ]* 6.2 Write integration tests for the Join Circle form
+    - Test file: `src/components/circle/__tests__/JoinCircleForm.test.tsx`
+    - Mock `useFreighterWallet`, `next/navigation`, and `fetch`
+    - Cover the same scenarios as the Profile page integration tests, adapted for the Join Circle form context
+    - _Requirements: 3.1, 3.2, 3.4, 3.5, 3.6, 5.3, 8.2, 8.4, 8.5, 9.3_
+
+- [x] 7. Final checkpoint — Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for a faster MVP
+- Each task references specific requirements for traceability
+- Properties 1–3 are tested in the hook test file; Properties 4–5 are tested in the component test file
+- The `role="alert"` error element is rendered by the parent form (Profile page / Join Circle form), not by `ConnectWalletButton` itself — Property 4 tests should render the full parent form with a mocked hook returning an error
+- The SSR guard (`typeof window !== 'undefined'`) must be in place before any Freighter API call in the hook
+- `@stellar/freighter-api` must be imported exclusively in the hook; neither form nor button should import from it directly

--- a/docs/sms-notifications.md
+++ b/docs/sms-notifications.md
@@ -42,7 +42,19 @@ Ajosave: Your contribution of 10.0000000 USDC to "Lagos Girls Monthly Ajo" (Cycl
 Ajosave: You missed your contribution of 10.0000000 USDC to "Lagos Girls Monthly Ajo". Your status is now "defaulted" and you cannot receive future payouts. Contact support if this is an error.
 ```
 
-### 5. Join Request Approved
+### 5. Contribution Reminder
+**Trigger:** Hourly cron, when `next_payout_at` is 24h or 2h away  
+**Recipients:** Active members with no confirmed contribution for the current cycle  
+**Frequency:** At most once per reminder window per cycle (idempotent via `contribution_reminders` table)  
+**Examples:**
+```
+Ajosave: Your contribution of 10.0000000 USDC to "Lagos Girls Monthly Ajo" is due in 24 hours. Please contribute now to avoid being marked as defaulted!
+```
+```
+Ajosave: Your contribution of 10.0000000 USDC to "Lagos Girls Monthly Ajo" is due in 2 hours. Please contribute now to avoid being marked as defaulted!
+```
+
+### 6. Join Request Approved
 **Trigger:** When a circle creator approves a join request (private circles only)  
 **Recipient:** The approved member  
 **Frequency:** Once per approval  
@@ -51,7 +63,7 @@ Ajosave: You missed your contribution of 10.0000000 USDC to "Lagos Girls Monthly
 Ajosave: Your join request for "Lagos Girls Monthly Ajo" has been approved! You'll be notified when the circle starts.
 ```
 
-### 6. Join Request Rejected
+### 7. Join Request Rejected
 **Trigger:** When a circle creator rejects a join request (private circles only)  
 **Recipient:** The rejected member  
 **Frequency:** Once per rejection  
@@ -95,6 +107,12 @@ Two cron endpoints handle scheduled notifications:
 - Sends reminder SMS to recipients
 - Authorization: `Bearer <CRON_SECRET>`
 
+#### `/api/cron/contribution-reminders` (Hourly)
+- Finds circles with `next_payout_at` in the 23–25h or 1–3h window
+- Sends reminder SMS to active members who haven't confirmed their contribution
+- Idempotent: uses `contribution_reminders` table to prevent duplicate sends
+- Authorization: `Bearer <CRON_SECRET>`
+
 #### `/api/cron/missed-contributions` (Daily)
 - Finds circles past their payout date
 - Identifies members who haven't contributed
@@ -110,6 +128,10 @@ Add to `vercel.json`:
   "crons": [
     {
       "path": "/api/cron/reminders",
+      "schedule": "0 * * * *"
+    },
+    {
+      "path": "/api/cron/contribution-reminders",
       "schedule": "0 * * * *"
     },
     {
@@ -139,6 +161,10 @@ jobs:
       - name: Send Payout Reminders
         run: |
           curl -X GET https://ajosave.app/api/cron/reminders \
+            -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}"
+      - name: Send Contribution Reminders
+        run: |
+          curl -X GET https://ajosave.app/api/cron/contribution-reminders \
             -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}"
 
   missed-contributions:

--- a/migrations/1746100000000_add-contribution-reminders-table.ts
+++ b/migrations/1746100000000_add-contribution-reminders-table.ts
@@ -1,0 +1,34 @@
+import { MigrationBuilder } from "node-pg-migrate";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createTable("contribution_reminders", {
+    id: { type: "uuid", primaryKey: true, default: pgm.func("gen_random_uuid()") },
+    member_id: {
+      type: "uuid",
+      notNull: true,
+      references: "members(id)",
+      onDelete: "CASCADE",
+    },
+    cycle_number: { type: "integer", notNull: true, check: "cycle_number > 0" },
+    reminder_type: {
+      type: "varchar(4)",
+      notNull: true,
+      check: "reminder_type IN ('24h', '2h')",
+    },
+    sent_at: { type: "timestamp", notNull: true, default: pgm.func("NOW()") },
+  });
+
+  pgm.addConstraint(
+    "contribution_reminders",
+    "unique_contribution_reminder",
+    "UNIQUE (member_id, cycle_number, reminder_type)"
+  );
+
+  pgm.createIndex("contribution_reminders", ["member_id", "cycle_number"], {
+    name: "idx_contribution_reminders_member",
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropTable("contribution_reminders");
+}

--- a/migrations/1746200000000_add-circle-messages-table.ts
+++ b/migrations/1746200000000_add-circle-messages-table.ts
@@ -1,0 +1,33 @@
+import { MigrationBuilder } from "node-pg-migrate";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createTable("circle_messages", {
+    id: { type: "uuid", primaryKey: true, default: pgm.func("gen_random_uuid()") },
+    circle_id: {
+      type: "uuid",
+      notNull: true,
+      references: "circles(id)",
+      onDelete: "CASCADE",
+    },
+    user_id: {
+      type: "varchar(255)",
+      notNull: true,
+      references: "users(id)",
+      onDelete: "CASCADE",
+    },
+    content: {
+      type: "text",
+      notNull: true,
+      check: "char_length(content) >= 1 AND char_length(content) <= 1000",
+    },
+    created_at: { type: "timestamp", notNull: true, default: pgm.func("NOW()") },
+  });
+
+  pgm.createIndex("circle_messages", ["circle_id", "created_at"], {
+    name: "idx_circle_messages_circle_created",
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropTable("circle_messages");
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@hookform/resolvers": "^3.9.0",
         "@sentry/nextjs": "^8.28.0",
+        "@stellar/freighter-api": "3.1.0",
         "@stellar/stellar-sdk": "^12.3.0",
         "@tanstack/react-query": "^5.40.0",
         "axios": "^1.7.2",
@@ -40,6 +41,7 @@
         "eslint": "^8.57.0",
         "eslint-config-next": "14.2.4",
         "eslint-config-prettier": "^9.1.0",
+        "fast-check": "4.6.0",
         "husky": "^9.0.11",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
@@ -2927,6 +2929,16 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@stellar/freighter-api": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@stellar/freighter-api/-/freighter-api-3.1.0.tgz",
+      "integrity": "sha512-hsoZwAR/jNVIt8ee6aHYcRKVk09hDLHmsfK2nUfqHUo7LuHtuHI59y/mDyrT4bp/qlklGZNd2nr0hRJyjau8WQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "semver": "^7.6.3"
       }
     },
     "node_modules/@stellar/js-xdr": {
@@ -6551,6 +6563,46 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/fast-check": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.6.0.tgz",
+      "integrity": "sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/fast-check/node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-copy": {
       "version": "3.0.2",
@@ -10796,14 +10848,6 @@
         }
       }
     },
-    "node_modules/pg-cloudflare": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
-      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/pg-connection-string": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
@@ -11071,6 +11115,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
+    "@stellar/freighter-api": "3.1.0",
     "@sentry/nextjs": "^8.28.0",
     "@stellar/stellar-sdk": "^12.3.0",
     "@tanstack/react-query": "^5.40.0",
@@ -71,6 +72,7 @@
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "eslint": "^8.57.0",
+    "fast-check": "4.6.0",
     "eslint-config-next": "14.2.4",
     "eslint-config-prettier": "^9.1.0",
     "husky": "^9.0.11",

--- a/src/app/api/circles/[id]/chat/route.ts
+++ b/src/app/api/circles/[id]/chat/route.ts
@@ -1,0 +1,132 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { query } from "@/lib/db";
+import { withErrorHandler, withRateLimit } from "@/server/middleware";
+import { getMessages, postMessage } from "@/server/services/chat.service";
+import { broadcastChatMessage } from "@/server/websocket";
+import type { ApiResponse, CircleMessage } from "@/types";
+
+// ─── GET /api/circles/[id]/chat ───────────────────────────────────────────────
+
+export const GET = withErrorHandler(async (req: NextRequest, ctx: unknown) => {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  const { params } = ctx as { params: { id: string } };
+  const circleId = params.id;
+  const userId = (session.user as { id: string }).id;
+
+  // Verify the requesting user is an active member of this circle
+  const { rows: memberRows } = await query<{ exists: boolean }>(
+    `SELECT 1 FROM members WHERE circle_id = $1 AND user_id = $2 AND status = 'active'`,
+    [circleId, userId]
+  );
+  if (memberRows.length === 0) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Forbidden" },
+      { status: 403 }
+    );
+  }
+
+  // Parse and validate `limit` query param (integer 1–100, default 50)
+  const { searchParams } = new URL(req.url);
+  const rawLimit = searchParams.get("limit");
+  let limit = 50;
+  if (rawLimit !== null) {
+    const parsed = parseInt(rawLimit, 10);
+    if (isNaN(parsed) || parsed < 1 || parsed > 100) {
+      return NextResponse.json<ApiResponse<never>>(
+        { success: false, error: "limit must be an integer between 1 and 100" },
+        { status: 400 }
+      );
+    }
+    limit = parsed;
+  }
+
+  // Parse and validate `before` query param (must be valid ISO 8601 if provided)
+  const rawBefore = searchParams.get("before");
+  let before: string | undefined;
+  if (rawBefore !== null) {
+    if (!isNaN(Date.parse(rawBefore))) {
+      before = rawBefore;
+    } else {
+      return NextResponse.json<ApiResponse<never>>(
+        { success: false, error: "before must be a valid ISO 8601 timestamp" },
+        { status: 400 }
+      );
+    }
+  }
+
+  const messages = await getMessages(circleId, { limit, before });
+
+  return NextResponse.json<ApiResponse<CircleMessage[]>>(
+    { success: true, data: messages },
+    { status: 200 }
+  );
+});
+
+// ─── POST /api/circles/[id]/chat ──────────────────────────────────────────────
+
+export const POST = withErrorHandler(
+  withRateLimit(
+    async (req: NextRequest, ctx: unknown) => {
+      const session = await getServerSession(authOptions);
+      if (!session?.user) {
+        return NextResponse.json<ApiResponse<never>>(
+          { success: false, error: "Unauthorized" },
+          { status: 401 }
+        );
+      }
+
+      const { params } = ctx as { params: { id: string } };
+      const circleId = params.id;
+      const userId = (session.user as { id: string }).id;
+
+      // Verify the requesting user is an active member of this circle
+      const { rows: memberRows } = await query<{ exists: boolean }>(
+        `SELECT 1 FROM members WHERE circle_id = $1 AND user_id = $2 AND status = 'active'`,
+        [circleId, userId]
+      );
+      if (memberRows.length === 0) {
+        return NextResponse.json<ApiResponse<never>>(
+          { success: false, error: "Forbidden" },
+          { status: 403 }
+        );
+      }
+
+      // Parse and validate request body
+      const { content } = await req.json();
+
+      if (!content || typeof content !== "string" || content.trim().length === 0) {
+        return NextResponse.json<ApiResponse<never>>(
+          { success: false, error: "content is required and must not be empty" },
+          { status: 400 }
+        );
+      }
+
+      if (content.length > 1000) {
+        return NextResponse.json<ApiResponse<never>>(
+          { success: false, error: "content must not exceed 1000 characters" },
+          { status: 400 }
+        );
+      }
+
+      const message = await postMessage(circleId, userId, content);
+
+      // Fire-and-forget broadcast; a failed broadcast does not roll back the DB insert
+      broadcastChatMessage(circleId, message);
+
+      return NextResponse.json<ApiResponse<CircleMessage>>(
+        { success: true, data: message },
+        { status: 201 }
+      );
+    },
+    { limit: 30, windowMs: 60_000 }
+  )
+);

--- a/src/app/api/cron/contribution-reminders/route.ts
+++ b/src/app/api/cron/contribution-reminders/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sendContributionReminders } from "@/server/services/scheduler.service";
+import { verifyCronSecret } from "@/lib/cron-auth";
+
+/**
+ * Cron endpoint to send contribution reminders.
+ *
+ * Triggers the Contribution_Reminder_Service, which identifies active circle
+ * members who have not yet confirmed their contribution and whose cycle deadline
+ * (`next_payout_at`) falls within the 24-hour (23–25 h) or 2-hour (1–3 h)
+ * reminder windows. Eligible members receive an SMS via the SMS_Notification_System.
+ *
+ * Schedule: Run hourly so that both reminder windows are checked at least once
+ * per hour (mirrors the cadence of `/api/cron/reminders`).
+ *
+ * Authorization: Bearer <CRON_SECRET>
+ */
+export async function GET(req: NextRequest) {
+  const unauth = verifyCronSecret(req);
+  if (unauth) return unauth;
+
+  try {
+    await sendContributionReminders();
+
+    return NextResponse.json({
+      success: true,
+      message: "Contribution reminders sent successfully",
+    });
+  } catch (error) {
+    console.error("Failed to send contribution reminders:", error);
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to send contribution reminders",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/circles/[id]/page.tsx
+++ b/src/app/circles/[id]/page.tsx
@@ -9,6 +9,7 @@ import { PayoutCountdown } from "@/components/circle/PayoutCountdown";
 import { getCurrencySymbol, SupportedCurrency } from "@/lib/currency";
 import { format } from "date-fns";
 import type { Metadata } from "next";
+import { CircleChat } from "@/components/circle/CircleChat";
 import styles from "./page.module.css";
 
 interface Props {
@@ -55,6 +56,7 @@ export default async function CircleDetailPage({ params }: Props) {
   const userId = (session?.user as { id?: string } | undefined)?.id;
   const isCreator = userId === circle.creatorId;
   const isMember = members.some((m) => m.userId === userId);
+  const isActiveMember = members.some((m) => m.userId === userId && m.status === "active");
   const currencySymbol = getCurrencySymbol(circle.contributionCurrency as SupportedCurrency);
 
   return (
@@ -113,6 +115,14 @@ export default async function CircleDetailPage({ params }: Props) {
             isCreator={isCreator}
           />
         </div>
+
+        {userId && (
+          <CircleChat
+            circleId={circle.id}
+            isActiveMember={isActiveMember}
+            currentUserId={userId}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -5,10 +5,14 @@ import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import styles from "./page.module.css";
 import type { ProfileData } from "@/app/api/profile/route";
+import { useFreighterWallet } from "@/hooks/useFreighterWallet";
+import { ConnectWalletButton } from "@/components/wallet/ConnectWalletButton";
 
 export default function ProfilePage() {
   const { data: session, status } = useSession();
   const router = useRouter();
+
+  const { connectionState, publicKey, error: walletError, connect, disconnect } = useFreighterWallet();
 
   const [profile, setProfile] = useState<ProfileData | null>(null);
   const [form, setForm] = useState({ displayName: "", email: "", stellarPublicKey: "" });
@@ -34,6 +38,18 @@ export default function ProfilePage() {
         }
       });
   }, [status]);
+
+  useEffect(() => {
+    if (publicKey !== null) {
+      setForm((f) => ({ ...f, stellarPublicKey: publicKey }));
+    }
+  }, [publicKey]);
+
+  useEffect(() => {
+    if (connectionState === "disconnected") {
+      setForm((f) => ({ ...f, stellarPublicKey: "" }));
+    }
+  }, [connectionState]);
 
   const handleSave = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -166,6 +182,27 @@ export default function ProfilePage() {
                 placeholder="GXXXXXXX…"
                 spellCheck={false}
               />
+              {connectionState !== "not_installed" && (
+                <ConnectWalletButton
+                  connectionState={connectionState}
+                  onConnect={connect}
+                  onDisconnect={disconnect}
+                  publicKey={publicKey}
+                />
+              )}
+              {connectionState === "not_installed" && (
+                <small className="input-hint">
+                  Don&apos;t have a Stellar wallet?{" "}
+                  <a href="https://freighter.app" target="_blank" rel="noopener noreferrer">
+                    Install Freighter
+                  </a>
+                </small>
+              )}
+              {walletError && (
+                <p role="alert" style={{ color: "var(--color-error)", fontSize: "0.875rem", marginTop: "0.25rem" }}>
+                  {walletError}
+                </p>
+              )}
             </div>
 
             {message && (

--- a/src/components/circle/CircleChat.module.css
+++ b/src/components/circle/CircleChat.module.css
@@ -1,0 +1,231 @@
+.container {
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  padding: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.heading {
+  font-size: var(--text-lg);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+/* ── Loading ─────────────────────────────────────────────────────────────── */
+.loading {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  padding: var(--space-4) 0;
+}
+
+.spinner {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-brand-primary);
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ── Error ───────────────────────────────────────────────────────────────── */
+.error {
+  color: var(--color-error, #dc2626);
+  font-size: var(--text-sm);
+  margin: 0;
+  padding: var(--space-2) var(--space-3);
+  background: color-mix(in srgb, var(--color-error, #dc2626) 10%, transparent);
+  border-radius: var(--radius-md);
+}
+
+/* ── Message list ────────────────────────────────────────────────────────── */
+.messageList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  max-height: 480px;
+  overflow-y: auto;
+  padding-right: var(--space-2);
+  scroll-behavior: smooth;
+}
+
+/* Scrollbar styling */
+.messageList::-webkit-scrollbar {
+  width: 4px;
+}
+.messageList::-webkit-scrollbar-track {
+  background: transparent;
+}
+.messageList::-webkit-scrollbar-thumb {
+  background: var(--color-border);
+  border-radius: var(--radius-full);
+}
+
+.empty {
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  text-align: center;
+  padding: var(--space-6) 0;
+  margin: 0;
+}
+
+/* ── Load earlier ────────────────────────────────────────────────────────── */
+.loadEarlier {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  padding-bottom: var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.loadEarlierBtn {
+  font-size: var(--text-xs);
+  color: var(--color-brand-primary);
+  background: none;
+  border: 1px solid var(--color-brand-primary);
+  border-radius: var(--radius-full);
+  padding: var(--space-1) var(--space-4);
+  cursor: pointer;
+  transition: background var(--transition-base), color var(--transition-base);
+}
+
+.loadEarlierBtn:hover:not(:disabled) {
+  background: var(--color-brand-primary);
+  color: #fff;
+}
+
+.loadEarlierBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ── Individual message ──────────────────────────────────────────────────── */
+.message {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-3);
+  background: var(--color-bg-base, var(--color-bg-surface));
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  max-width: 85%;
+  align-self: flex-start;
+}
+
+.messageSelf {
+  align-self: flex-end;
+  background: color-mix(in srgb, var(--color-brand-primary) 8%, var(--color-bg-surface));
+  border-color: color-mix(in srgb, var(--color-brand-primary) 30%, var(--color-border));
+}
+
+.messageHeader {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.displayName {
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  color: var(--color-brand-primary);
+}
+
+.timestamp {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  margin-left: auto;
+}
+
+.content {
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ── Input area ──────────────────────────────────────────────────────────── */
+.inputArea {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  border-top: 1px solid var(--color-border);
+  padding-top: var(--space-4);
+}
+
+.inputRow {
+  display: flex;
+  gap: var(--space-2);
+  align-items: flex-end;
+}
+
+.textarea {
+  flex: 1;
+  resize: none;
+  padding: var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-base, var(--color-bg-surface));
+  color: var(--color-text-primary);
+  font-size: var(--text-sm);
+  font-family: inherit;
+  line-height: 1.5;
+  transition: border-color var(--transition-base);
+}
+
+.textarea:focus {
+  outline: none;
+  border-color: var(--color-brand-primary);
+}
+
+.textarea:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.sendBtn {
+  padding: var(--space-3) var(--space-5);
+  background: var(--color-brand-primary);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-lg);
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: opacity var(--transition-base);
+  align-self: flex-end;
+}
+
+.sendBtn:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
+.sendBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ── Read-only notice ────────────────────────────────────────────────────── */
+.readOnlyNotice {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  text-align: center;
+  padding: var(--space-3);
+  border-top: 1px solid var(--color-border);
+  margin: 0;
+}

--- a/src/components/circle/CircleChat.tsx
+++ b/src/components/circle/CircleChat.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRealtimeUpdates } from "@/hooks/useRealtimeUpdates";
+import type { CircleMessage } from "@/types";
+import { format } from "date-fns";
+import styles from "./CircleChat.module.css";
+
+interface CircleChatProps {
+  circleId: string;
+  isActiveMember: boolean;
+  currentUserId: string;
+}
+
+const LIMIT = 50;
+
+const fetchMessages = async (
+  circleId: string,
+  limit: number,
+  before?: string
+): Promise<CircleMessage[]> => {
+  const url = `/api/circles/${circleId}/chat?limit=${limit}${before ? `&before=${encodeURIComponent(before)}` : ""}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error("Failed to load messages");
+  const json = await res.json();
+  return json.data as CircleMessage[];
+};
+
+const sendMessage = async (
+  circleId: string,
+  content: string
+): Promise<CircleMessage> => {
+  const res = await fetch(`/api/circles/${circleId}/chat`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ content }),
+  });
+  if (!res.ok) throw new Error("Failed to send message");
+  const json = await res.json();
+  return json.data as CircleMessage;
+};
+
+function deduplicateById(messages: CircleMessage[]): CircleMessage[] {
+  const seen = new Set<string>();
+  return messages.filter((m) => {
+    if (seen.has(m.id)) return false;
+    seen.add(m.id);
+    return true;
+  });
+}
+
+export function CircleChat({
+  circleId,
+  isActiveMember,
+  currentUserId,
+}: CircleChatProps) {
+  const queryClient = useQueryClient();
+
+  // Local state for the combined message list
+  const [messages, setMessages] = useState<CircleMessage[]>([]);
+  // Extra messages received via WebSocket (appended in real-time)
+  const [extraMessages, setExtraMessages] = useState<CircleMessage[]>([]);
+  // Whether there are potentially more messages to load
+  const [hasMore, setHasMore] = useState(false);
+
+  const [inputValue, setInputValue] = useState("");
+  const [postError, setPostError] = useState<string | null>(null);
+
+  const listRef = useRef<HTMLDivElement>(null);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  // ── Initial fetch via React Query ──────────────────────────────────────────
+  const {
+    data: queryData,
+    isLoading,
+    isError,
+    error: queryError,
+  } = useQuery<CircleMessage[], Error>({
+    queryKey: ["circle-chat", circleId],
+    queryFn: () => fetchMessages(circleId, LIMIT),
+    enabled: isActiveMember,
+    staleTime: 30_000,
+  });
+
+  // Populate messages state when initial query resolves
+  useEffect(() => {
+    if (queryData) {
+      setMessages(queryData);
+      setHasMore(queryData.length === LIMIT);
+    }
+  }, [queryData]);
+
+  // ── Combine query messages + real-time extras ──────────────────────────────
+  const allMessages = deduplicateById([...messages, ...extraMessages]);
+
+  // ── Auto-scroll to bottom on list update ──────────────────────────────────
+  useEffect(() => {
+    if (bottomRef.current) {
+      bottomRef.current.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [allMessages.length]);
+
+  // ── Real-time updates ──────────────────────────────────────────────────────
+  const handleChatMessage = useCallback(
+    (data: CircleMessage) => {
+      setExtraMessages((prev) => {
+        // Only append if not already in the base messages list
+        const alreadyInBase = messages.some((m) => m.id === data.id);
+        const alreadyInExtra = prev.some((m) => m.id === data.id);
+        if (alreadyInBase || alreadyInExtra) return prev;
+        return [...prev, data];
+      });
+    },
+    [messages]
+  );
+
+  useRealtimeUpdates({
+    circleId,
+    onChatMessage: handleChatMessage,
+  });
+
+  // ── Send message mutation ──────────────────────────────────────────────────
+  const mutation = useMutation<CircleMessage, Error, string>({
+    mutationFn: (content: string) => sendMessage(circleId, content),
+    onSuccess: () => {
+      setInputValue("");
+      setPostError(null);
+      // Invalidate query so the next fetch picks up the new message
+      queryClient.invalidateQueries({ queryKey: ["circle-chat", circleId] });
+    },
+    onError: (err) => {
+      setPostError(err.message || "Failed to send message");
+    },
+  });
+
+  const handleSend = () => {
+    const trimmed = inputValue.trim();
+    if (!trimmed || mutation.isPending) return;
+    setPostError(null);
+    mutation.mutate(trimmed);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  // ── Load earlier messages ──────────────────────────────────────────────────
+  const [isLoadingEarlier, setIsLoadingEarlier] = useState(false);
+  const [loadEarlierError, setLoadEarlierError] = useState<string | null>(null);
+
+  const handleLoadEarlier = async () => {
+    if (messages.length === 0) return;
+    const oldest = messages[0];
+    const scrollContainer = listRef.current;
+
+    // Save scroll position before prepending
+    const prevScrollHeight = scrollContainer?.scrollHeight ?? 0;
+    const prevScrollTop = scrollContainer?.scrollTop ?? 0;
+
+    setIsLoadingEarlier(true);
+    setLoadEarlierError(null);
+
+    try {
+      const older = await fetchMessages(circleId, LIMIT, oldest.createdAt);
+      setMessages((prev) => deduplicateById([...older, ...prev]));
+      setHasMore(older.length === LIMIT);
+
+      // Restore scroll position after prepend
+      requestAnimationFrame(() => {
+        if (scrollContainer) {
+          const newScrollHeight = scrollContainer.scrollHeight;
+          scrollContainer.scrollTop =
+            prevScrollTop + (newScrollHeight - prevScrollHeight);
+        }
+      });
+    } catch (err) {
+      setLoadEarlierError(
+        err instanceof Error ? err.message : "Failed to load earlier messages"
+      );
+    } finally {
+      setIsLoadingEarlier(false);
+    }
+  };
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+  return (
+    <section className={styles.container} aria-label="Circle chat">
+      <h2 className={styles.heading}>Circle Chat</h2>
+
+      {/* Loading state */}
+      {isLoading && (
+        <div className={styles.loading} aria-busy="true" aria-live="polite">
+          <span className={styles.spinner} aria-hidden="true" />
+          <span>Loading messages…</span>
+        </div>
+      )}
+
+      {/* GET error */}
+      {isError && (
+        <p className={styles.error} role="alert">
+          {(queryError as Error)?.message ?? "Failed to load messages"}
+        </p>
+      )}
+
+      {/* Message list */}
+      {!isLoading && !isError && (
+        <div
+          ref={listRef}
+          className={styles.messageList}
+          role="log"
+          aria-label="Chat messages"
+          aria-live="polite"
+          aria-relevant="additions"
+        >
+          {/* Load earlier button */}
+          {hasMore && (
+            <div className={styles.loadEarlier}>
+              <button
+                className={styles.loadEarlierBtn}
+                onClick={handleLoadEarlier}
+                disabled={isLoadingEarlier}
+                aria-busy={isLoadingEarlier}
+              >
+                {isLoadingEarlier ? "Loading…" : "Load earlier messages"}
+              </button>
+              {loadEarlierError && (
+                <p className={styles.error} role="alert">
+                  {loadEarlierError}
+                </p>
+              )}
+            </div>
+          )}
+
+          {allMessages.length === 0 && (
+            <p className={styles.empty}>
+              No messages yet. Be the first to say something!
+            </p>
+          )}
+
+          {allMessages.map((msg) => (
+            <article
+              key={msg.id}
+              className={`${styles.message} ${msg.userId === currentUserId ? styles.messageSelf : ""}`}
+            >
+              <header className={styles.messageHeader}>
+                <span className={styles.displayName}>{msg.displayName}</span>
+                <time
+                  className={styles.timestamp}
+                  dateTime={msg.createdAt}
+                  title={format(new Date(msg.createdAt), "PPpp")}
+                >
+                  {format(new Date(msg.createdAt), "MMM d, h:mm a")}
+                </time>
+              </header>
+              <p className={styles.content}>{msg.content}</p>
+            </article>
+          ))}
+
+          {/* Scroll anchor */}
+          <div ref={bottomRef} aria-hidden="true" />
+        </div>
+      )}
+
+      {/* Input area */}
+      {isActiveMember ? (
+        <div className={styles.inputArea}>
+          {postError && (
+            <p className={styles.error} role="alert">
+              {postError}
+            </p>
+          )}
+          <div className={styles.inputRow}>
+            <textarea
+              className={styles.textarea}
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Type a message… (Enter to send)"
+              aria-label="Message input"
+              aria-multiline="true"
+              rows={2}
+              maxLength={1000}
+              disabled={mutation.isPending}
+            />
+            <button
+              className={styles.sendBtn}
+              onClick={handleSend}
+              disabled={mutation.isPending || !inputValue.trim()}
+              aria-busy={mutation.isPending}
+              aria-label="Send message"
+            >
+              {mutation.isPending ? "Sending…" : "Send"}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <p className={styles.readOnlyNotice} role="status">
+          Only active members can post messages
+        </p>
+      )}
+    </section>
+  );
+}

--- a/src/components/circle/JoinCircleForm.tsx
+++ b/src/components/circle/JoinCircleForm.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/Button";
 import { getCurrencySymbol, SupportedCurrency } from "@/lib/currency";
 import type { Circle } from "@/types";
 import styles from "./JoinCircleForm.module.css";
+import { useFreighterWallet } from "@/hooks/useFreighterWallet";
+import { ConnectWalletButton } from "@/components/wallet/ConnectWalletButton";
 
 interface Props {
   circle: Circle;
@@ -18,6 +20,20 @@ export function JoinCircleForm({ circle, token, inviteValid }: Props) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [stellarPublicKey, setStellarPublicKey] = useState("");
+
+  const { connectionState, publicKey, error: walletError, connect, disconnect } = useFreighterWallet();
+
+  useEffect(() => {
+    if (publicKey !== null) {
+      setStellarPublicKey(publicKey);
+    }
+  }, [publicKey]);
+
+  useEffect(() => {
+    if (connectionState === "disconnected") {
+      setStellarPublicKey("");
+    }
+  }, [connectionState]);
 
   const currencySymbol = getCurrencySymbol(circle.contributionCurrency as SupportedCurrency);
 
@@ -85,6 +101,27 @@ export function JoinCircleForm({ circle, token, inviteValid }: Props) {
           <p className={styles.help}>
             This is where your payouts will be sent. Make sure it's a valid Stellar address.
           </p>
+          {connectionState !== "not_installed" && (
+            <ConnectWalletButton
+              connectionState={connectionState}
+              onConnect={connect}
+              onDisconnect={disconnect}
+              publicKey={publicKey}
+            />
+          )}
+          {connectionState === "not_installed" && (
+            <p className={styles.help}>
+              Don&apos;t have a Stellar wallet?{" "}
+              <a href="https://freighter.app" target="_blank" rel="noopener noreferrer">
+                Install Freighter
+              </a>
+            </p>
+          )}
+          {walletError && (
+            <p role="alert" style={{ color: "var(--color-error)", fontSize: "0.875rem", marginTop: "0.25rem" }}>
+              {walletError}
+            </p>
+          )}
         </div>
 
         {error && <div className={styles.error}>{error}</div>}

--- a/src/components/wallet/ConnectWalletButton.module.css
+++ b/src/components/wallet/ConnectWalletButton.module.css
@@ -1,0 +1,65 @@
+/* Primary-style button for connect/disconnect actions */
+.connectButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #ffffff;
+  background-color: #4f46e5;
+  border: none;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  transition: background-color 0.15s ease-in-out;
+}
+
+.connectButton:hover:not(:disabled) {
+  background-color: #4338ca;
+}
+
+.connectButton:focus-visible {
+  outline: 2px solid #4f46e5;
+  outline-offset: 2px;
+}
+
+/* Muted/disabled appearance for the connecting state */
+.connectingButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #9ca3af;
+  background-color: #e5e7eb;
+  border: none;
+  border-radius: 0.375rem;
+  cursor: not-allowed;
+}
+
+/* Small inline spinner animation */
+.spinner {
+  display: inline-block;
+  width: 0.875rem;
+  height: 0.875rem;
+  border: 2px solid #9ca3af;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Small muted text for the connected status */
+.statusMessage {
+  margin: 0 0 0.5rem 0;
+  font-size: 0.75rem;
+  color: #6b7280;
+  font-family: monospace;
+}

--- a/src/components/wallet/ConnectWalletButton.tsx
+++ b/src/components/wallet/ConnectWalletButton.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { ConnectionState } from "@/hooks/useFreighterWallet";
+import styles from "./ConnectWalletButton.module.css";
+
+interface ConnectWalletButtonProps {
+  connectionState: ConnectionState;
+  onConnect: () => void;
+  onDisconnect: () => void;
+  publicKey: string | null;
+}
+
+export function ConnectWalletButton({
+  connectionState,
+  onConnect,
+  onDisconnect,
+  publicKey,
+}: ConnectWalletButtonProps): JSX.Element | null {
+  if (connectionState === "not_installed") {
+    return null;
+  }
+
+  if (connectionState === "disconnected") {
+    return (
+      <button
+        type="button"
+        className={styles.connectButton}
+        aria-label="Connect Freighter Wallet"
+        onClick={onConnect}
+      >
+        Connect Wallet
+      </button>
+    );
+  }
+
+  if (connectionState === "connecting") {
+    return (
+      <button
+        type="button"
+        className={styles.connectingButton}
+        aria-label="Connect Freighter Wallet"
+        aria-busy="true"
+        aria-disabled="true"
+        disabled
+      >
+        <span className={styles.spinner} aria-hidden="true" />
+        Connecting…
+      </button>
+    );
+  }
+
+  // connectionState === "connected"
+  return (
+    <>
+      <p role="status" className={styles.statusMessage}>
+        Connected: {publicKey!.slice(0, 8)}…{publicKey!.slice(-4)}
+      </p>
+      <button
+        type="button"
+        className={styles.connectButton}
+        aria-label="Disconnect Freighter Wallet"
+        onClick={onDisconnect}
+      >
+        Disconnect
+      </button>
+    </>
+  );
+}

--- a/src/hooks/useFreighterWallet.ts
+++ b/src/hooks/useFreighterWallet.ts
@@ -1,0 +1,156 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  isConnected,
+  requestAccess,
+  getNetwork,
+} from "@stellar/freighter-api";
+
+export type ConnectionState =
+  | "not_installed"
+  | "disconnected"
+  | "connecting"
+  | "connected";
+
+export interface UseFreighterWalletReturn {
+  connectionState: ConnectionState;
+  publicKey: string | null;
+  error: string | null;
+  connect: () => Promise<void>;
+  disconnect: () => void;
+}
+
+interface WalletState {
+  connectionState: ConnectionState;
+  publicKey: string | null;
+  error: string | null;
+}
+
+export function useFreighterWallet(): UseFreighterWalletReturn {
+  const [state, setState] = useState<WalletState>({
+    connectionState: "not_installed",
+    publicKey: null,
+    error: null,
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const detect = async () => {
+      try {
+        const result = await isConnected();
+        if (result.isConnected === true) {
+          setState((prev) => ({ ...prev, connectionState: "disconnected" }));
+        } else {
+          setState((prev) => ({ ...prev, connectionState: "not_installed" }));
+        }
+      } catch (err) {
+        console.error("Freighter isConnected() failed:", err);
+        setState((prev) => ({ ...prev, connectionState: "not_installed" }));
+      }
+    };
+
+    detect();
+  }, []);
+
+  const connect = async (): Promise<void> => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    setState((prev) => ({ ...prev, connectionState: "connecting", error: null }));
+
+    try {
+      // Request access from Freighter
+      const accessResult = await requestAccess();
+
+      if (accessResult.error) {
+        const errorStr = String(accessResult.error);
+        let message: string;
+
+        if (/rejected|denied/i.test(errorStr)) {
+          message =
+            "Connection request was rejected. You can enter your Stellar key manually.";
+        } else if (/locked/i.test(errorStr)) {
+          message =
+            "Your Freighter wallet is locked. Please unlock it and try again.";
+        } else {
+          console.error("Unexpected Freighter requestAccess error:", errorStr);
+          message = "An unexpected error occurred. Please try again.";
+        }
+
+        setState((prev) => ({
+          ...prev,
+          connectionState: "disconnected",
+          error: message,
+        }));
+        return;
+      }
+
+      // Validate the returned address
+      const address = accessResult.address;
+      if (
+        typeof address !== "string" ||
+        address.length !== 56 ||
+        !address.startsWith("G")
+      ) {
+        setState((prev) => ({
+          ...prev,
+          connectionState: "disconnected",
+          error:
+            "The key returned by Freighter is not a valid Stellar public key.",
+        }));
+        return;
+      }
+
+      // Verify the network
+      const networkResult = await getNetwork();
+
+      if (
+        networkResult.error ||
+        networkResult.network.toUpperCase() !== "PUBLIC"
+      ) {
+        const detectedNetwork = networkResult.network || "unknown";
+        setState((prev) => ({
+          ...prev,
+          connectionState: "disconnected",
+          error: `Freighter is connected to ${detectedNetwork}, but this app requires Pubnet. Please switch networks in Freighter and try again.`,
+        }));
+        return;
+      }
+
+      // Success
+      setState({
+        connectionState: "connected",
+        publicKey: address,
+        error: null,
+      });
+    } catch (err) {
+      console.error("Unexpected error in useFreighterWallet.connect():", err);
+      setState((prev) => ({
+        ...prev,
+        connectionState: "disconnected",
+        error: "An unexpected error occurred. Please try again.",
+      }));
+    }
+  };
+
+  const disconnect = (): void => {
+    setState({
+      connectionState: "disconnected",
+      publicKey: null,
+      error: null,
+    });
+  };
+
+  return {
+    connectionState: state.connectionState,
+    publicKey: state.publicKey,
+    error: state.error,
+    connect,
+    disconnect,
+  };
+}

--- a/src/hooks/useRealtimeUpdates.ts
+++ b/src/hooks/useRealtimeUpdates.ts
@@ -13,6 +13,7 @@ interface UseRealtimeUpdatesOptions {
   onPayoutProcessed?: (data: WebSocketEvents["payout:processed"]) => void;
   onCircleCompleted?: (data: WebSocketEvents["circle:completed"]) => void;
   onCircleStarted?: (data: WebSocketEvents["circle:started"]) => void;
+  onChatMessage?: (data: WebSocketEvents["chat:message"]) => void;
 }
 
 export function useRealtimeUpdates(options: UseRealtimeUpdatesOptions) {
@@ -23,6 +24,7 @@ export function useRealtimeUpdates(options: UseRealtimeUpdatesOptions) {
     onPayoutProcessed,
     onCircleCompleted,
     onCircleStarted,
+    onChatMessage,
   } = options;
 
   const socketRef = useRef<Socket | null>(null);
@@ -84,6 +86,10 @@ export function useRealtimeUpdates(options: UseRealtimeUpdatesOptions) {
       socket.on("circle:started", onCircleStarted);
     }
 
+    if (onChatMessage) {
+      socket.on("chat:message", onChatMessage);
+    }
+
     // Cleanup on unmount
     return () => {
       if (circleId) {
@@ -98,6 +104,7 @@ export function useRealtimeUpdates(options: UseRealtimeUpdatesOptions) {
     onPayoutProcessed,
     onCircleCompleted,
     onCircleStarted,
+    onChatMessage,
   ]);
 
   return {

--- a/src/lib/sms.ts
+++ b/src/lib/sms.ts
@@ -56,6 +56,16 @@ export async function sendMissedContributionSms(
   await sendSms(phone, message);
 }
 
+export async function sendContributionReminderSms(
+  phone: string,
+  circleName: string,
+  amount: string,
+  hoursLeft: number
+): Promise<void> {
+  const message = `Ajosave: Your contribution of ${amount} USDC to "${circleName}" is due in ${hoursLeft} hours. Please contribute now to avoid being marked as defaulted!`;
+  await sendSms(phone, message);
+}
+
 export async function sendContributionReceivedSms(
   phone: string,
   circleName: string,

--- a/src/server/services/chat.service.ts
+++ b/src/server/services/chat.service.ts
@@ -1,0 +1,66 @@
+import { query } from "@/lib/db";
+import type { CircleMessage } from "@/types";
+
+export interface GetMessagesOptions {
+  limit?: number;  // 1–100, default 50
+  before?: string; // ISO 8601 timestamp cursor
+}
+
+export async function postMessage(
+  circleId: string,
+  userId: string,
+  content: string
+): Promise<CircleMessage> {
+  const insertResult = await query<{ id: string }>(
+    `INSERT INTO circle_messages (id, circle_id, user_id, content, created_at)
+     VALUES (gen_random_uuid(), $1, $2, $3, NOW())
+     RETURNING id`,
+    [circleId, userId, content]
+  );
+
+  const messageId = insertResult.rows[0].id;
+
+  const { rows } = await query<CircleMessage>(
+    `SELECT
+       cm.id,
+       cm.circle_id   AS "circleId",
+       cm.user_id     AS "userId",
+       u.display_name AS "displayName",
+       cm.content,
+       cm.created_at  AS "createdAt"
+     FROM circle_messages cm
+     JOIN users u ON u.id = cm.user_id
+     WHERE cm.id = $1`,
+    [messageId]
+  );
+
+  return rows[0];
+}
+
+export async function getMessages(
+  circleId: string,
+  options?: GetMessagesOptions
+): Promise<CircleMessage[]> {
+  const rawLimit = options?.limit ?? 50;
+  const limit = Math.min(Math.max(rawLimit, 1), 100);
+  const before = options?.before ?? null;
+
+  const { rows } = await query<CircleMessage>(
+    `SELECT
+       cm.id,
+       cm.circle_id   AS "circleId",
+       cm.user_id     AS "userId",
+       u.display_name AS "displayName",
+       cm.content,
+       cm.created_at  AS "createdAt"
+     FROM circle_messages cm
+     JOIN users u ON u.id = cm.user_id
+     WHERE cm.circle_id = $1
+       AND ($2::timestamp IS NULL OR cm.created_at < $2::timestamp)
+     ORDER BY cm.created_at ASC
+     LIMIT $3`,
+    [circleId, before, limit]
+  );
+
+  return rows;
+}

--- a/src/server/services/notification.service.ts
+++ b/src/server/services/notification.service.ts
@@ -3,6 +3,7 @@ import {
   sendPayoutReminderSms,
   sendPayoutProcessedSms,
   sendMissedContributionSms,
+  sendContributionReminderSms,
   sendContributionReceivedSms,
   sendJoinRequestApprovedSms,
   sendJoinRequestRejectedSms,
@@ -51,6 +52,29 @@ export async function notifyPayoutReminder(
     await sendPayoutReminderSms(phone, circleName, amount, hoursUntilPayout);
   } catch (error) {
     console.error(`Failed to send payout reminder to ${userId}:`, error);
+  }
+}
+
+/**
+ * Send a contribution reminder SMS to a member before the cycle deadline.
+ * Checks that the user has SMS notifications enabled and a phone number on file.
+ * Logs but does not throw if the SMS delivery fails.
+ */
+export async function notifyContributionReminder(
+  userId: string,
+  circleName: string,
+  amount: string,
+  hoursLeft: number
+): Promise<void> {
+  if (!(await canSendSms(userId))) return;
+
+  const phone = await getUserPhone(userId);
+  if (!phone) return;
+
+  try {
+    await sendContributionReminderSms(phone, circleName, amount, hoursLeft);
+  } catch (error) {
+    console.error(`Failed to send contribution reminder to ${userId}:`, error);
   }
 }
 

--- a/src/server/services/scheduler.service.ts
+++ b/src/server/services/scheduler.service.ts
@@ -1,5 +1,5 @@
 import { query } from "@/lib/db";
-import { notifyPayoutReminder, notifyMissedContribution } from "./notification.service";
+import { notifyPayoutReminder, notifyMissedContribution, notifyContributionReminder } from "./notification.service";
 import { getMissedContributions } from "./contribution.service";
 import type { Circle, Member } from "@/types";
 
@@ -87,6 +87,97 @@ export async function processMissedContributions(): Promise<void> {
       }
     } catch (error) {
       console.error(`Failed to process missed contributions for circle ${circle.id}:`, error);
+    }
+  }
+}
+
+type ReminderWindow = { hoursLeft: number; lowerBound: string; upperBound: string };
+
+const WINDOWS: ReminderWindow[] = [
+  { hoursLeft: 24, lowerBound: '23 hours', upperBound: '25 hours' },
+  { hoursLeft: 2,  lowerBound: '1 hour',   upperBound: '3 hours'  },
+];
+
+/**
+ * Send contribution reminders for both the 24h and 2h windows.
+ * Idempotent: uses the contribution_reminders table to prevent duplicates.
+ * Per-circle errors are caught and logged; they do not abort the run.
+ */
+export async function sendContributionReminders(): Promise<void> {
+  for (const { hoursLeft, lowerBound, upperBound } of WINDOWS) {
+    const reminderType = `${hoursLeft}h`;
+
+    const { rows: circles } = await query<Circle>(
+      `SELECT id, name, status, next_payout_at as "nextPayoutAt",
+              current_cycle as "currentCycle", contribution_usdc as "contributionUsdc"
+       FROM circles
+       WHERE status = 'active'
+         AND next_payout_at IS NOT NULL
+         AND next_payout_at > NOW() + INTERVAL '${lowerBound}'
+         AND next_payout_at < NOW() + INTERVAL '${upperBound}'`
+    );
+
+    for (const circle of circles) {
+      try {
+        const { rows: members } = await query<{ id: string; userId: string }>(
+          `SELECT m.id, m.user_id as "userId"
+           FROM members m
+           WHERE m.circle_id = $1
+             AND m.status = 'active'`,
+          [circle.id]
+        );
+
+        for (const member of members) {
+          // Check if member has already confirmed their contribution for this cycle
+          const { rows: confirmedRows } = await query(
+            `SELECT 1 FROM contributions
+             WHERE member_id = $1
+               AND circle_id = $2
+               AND cycle_number = $3
+               AND status = 'confirmed'`,
+            [member.id, circle.id, circle.currentCycle]
+          );
+          if (confirmedRows.length > 0) continue; // already confirmed — not a Pending_Contributor
+
+          // Check if contribution is 'missed' — also not a Pending_Contributor
+          const { rows: statusRows } = await query<{ status: string }>(
+            `SELECT status FROM contributions
+             WHERE member_id = $1
+               AND circle_id = $2
+               AND cycle_number = $3`,
+            [member.id, circle.id, circle.currentCycle]
+          );
+          if (statusRows.length > 0 && statusRows[0].status === 'missed') continue;
+
+          // Check idempotency — has this reminder already been sent?
+          const { rows: reminderRows } = await query(
+            `SELECT 1 FROM contribution_reminders
+             WHERE member_id = $1
+               AND cycle_number = $2
+               AND reminder_type = $3`,
+            [member.id, circle.currentCycle, reminderType]
+          );
+          if (reminderRows.length > 0) continue; // already reminded this window/cycle
+
+          // Send the reminder
+          await notifyContributionReminder(
+            member.userId,
+            circle.name,
+            circle.contributionUsdc,
+            hoursLeft
+          );
+
+          // Record that we sent the reminder (idempotency insert)
+          await query(
+            `INSERT INTO contribution_reminders (id, member_id, cycle_number, reminder_type, sent_at)
+             VALUES (gen_random_uuid(), $1, $2, $3, NOW())
+             ON CONFLICT DO NOTHING`,
+            [member.id, circle.currentCycle, reminderType]
+          );
+        }
+      } catch (error) {
+        console.error(`Failed to send contribution reminders for circle ${circle.id}:`, error);
+      }
     }
   }
 }

--- a/src/server/websocket.ts
+++ b/src/server/websocket.ts
@@ -32,6 +32,14 @@ export interface WebSocketEvents {
     circleId: string;
     timestamp: string;
   };
+  "chat:message": {
+    id: string;
+    circleId: string;
+    userId: string;
+    displayName: string;
+    content: string;
+    createdAt: string;
+  };
 }
 
 /**
@@ -167,6 +175,18 @@ export function broadcastCircleCompleted(circleId: string): void {
 
   io.to(`circle:${circleId}`).emit("circle:completed", event);
   console.log(`[websocket] Broadcasted circle:completed to circle:${circleId}`);
+}
+
+/**
+ * Broadcast a new chat message to all members in a circle room
+ */
+export function broadcastChatMessage(
+  circleId: string,
+  message: WebSocketEvents["chat:message"]
+): void {
+  if (!io) return;
+  io.to(`circle:${circleId}`).emit("chat:message", message);
+  console.log(`[websocket] Broadcasted chat:message to circle:${circleId}`);
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -81,6 +81,16 @@ export interface Payout {
   paidAt: Date;
 }
 
+// ─── Circle Chat ──────────────────────────────────────────────────────────────
+export interface CircleMessage {
+  id: string;
+  circleId: string;
+  userId: string;
+  displayName: string;  // joined from users table at read time
+  content: string;
+  createdAt: string;    // ISO 8601 string
+}
+
 // ─── API ──────────────────────────────────────────────────────────────────────
 export interface ApiSuccess<T> {
   success: true;


### PR DESCRIPTION
close #126 
close #127 

Description:

#126 — Contribution reminder notifications
Automated SMS reminders to active members who haven't contributed, at 24h and 2h before the cycle deadline.

Migration: contribution_reminders table with idempotency constraint
New cron endpoint GET /api/cron/contribution-reminders (hourly, Bearer auth)
Scheduler with 24h/2h window logic and duplicate-prevention via DB constraint
sms-notifications.md
 updated with new notification type and cron config
#127 — Circle chat
Persistent real-time message thread per circle. Active members only.

Migration: circle_messages table (1–1000 char constraint, indexed)
GET/POST /api/circles/[id]/chat with auth, active-member gate, rate limiting
Real-time delivery via existing Socket.io infrastructure (chat:message event)
CircleChat client component with React Query, auto-scroll, cursor pagination
Wired into the circle detail page