### PR TITLE
fix: add form validation feedback to CreateCircleForm

### DIFF
--- a/src/components/circle/CreateCircleForm.module.css
+++ b/src/components/circle/CreateCircleForm.module.css
@@ -1,5 +1,6 @@
 .form { display: flex; flex-direction: column; gap: var(--space-5); width: 100%; max-width: 480px; }
 .title { font-size: var(--text-2xl); font-weight: var(--font-bold); color: var(--color-text-primary); }
 .error { font-size: var(--text-sm); color: var(--color-error); background: rgba(239,68,68,0.1); border: 1px solid rgba(239,68,68,0.3); border-radius: var(--radius-md); padding: var(--space-3) var(--space-4); }
+.fieldError { font-size: var(--text-sm); color: var(--color-error); margin-top: var(--space-1); }
 .usdcPreview { font-size: var(--text-sm); color: var(--color-brand-primary); margin-top: calc(var(--space-2) * -1); }
 .rateSource { font-size: var(--text-xs); color: var(--color-text-muted); }

--- a/src/components/circle/CreateCircleForm.tsx
+++ b/src/components/circle/CreateCircleForm.tsx
@@ -50,13 +50,13 @@ function useUsdcPreview(amount: number | undefined, currency: string) {
 
 export function CreateCircleForm() {
   const router = useRouter();
-  const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [activeTemplateId, setActiveTemplateId] = useState<string | null>(null);
 
-  const { register, handleSubmit, control, reset, formState: { errors } } = useForm<CreateCircleInput>({
+  const { register, handleSubmit, control, reset, formState: { errors, isSubmitting } } = useForm<CreateCircleInput>({
     resolver: zodResolver(createCircleSchema),
     defaultValues: FORM_DEFAULTS,
+    mode: "onBlur",
   });
 
   const handleTemplateSelect = (template: CircleTemplate | null) => {
@@ -74,7 +74,6 @@ export function CreateCircleForm() {
   const { usdc, fetchedAt } = useUsdcPreview(contributionAmount, contributionCurrency);
 
   const onSubmit = async (data: CreateCircleInput) => {
-    setLoading(true);
     setError(null);
     try {
       const res = await fetch("/api/circles", {
@@ -87,8 +86,6 @@ export function CreateCircleForm() {
       router.push(`/circles/${json.data.id}`);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Something went wrong");
-    } finally {
-      setLoading(false);
     }
   };
 
@@ -146,6 +143,7 @@ export function CreateCircleForm() {
           <option value="biweekly">Bi-weekly</option>
           <option value="monthly">Monthly</option>
         </select>
+        {errors.cycleFrequency && <p className={styles.fieldError}>{errors.cycleFrequency.message}</p>}
       </div>
 
       <div className="input-group">
@@ -157,11 +155,12 @@ export function CreateCircleForm() {
         <small className="input-hint">
           Private circles require you to approve each join request
         </small>
+        {errors.circleType && <p className={styles.fieldError}>{errors.circleType.message}</p>}
       </div>
 
       {error && <p className={styles.error}>{error}</p>}
 
-      <Button type="submit" fullWidth loading={loading}>Create Circle</Button>
+      <Button type="submit" fullWidth loading={isSubmitting} disabled={isSubmitting}>Create Circle</Button>
     </form>
   );
 }

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -9,8 +9,9 @@ export const createCircleSchema = z.object({
   contributionCurrency: z.enum(["NGN", "GBP", "USD", "EUR"], {
     errorMap: () => ({ message: "Currency must be NGN, GBP, USD, or EUR" }),
   }),
-  maxMembers: z.number().min(2, "Minimum 2 members").max(20, "Maximum 20 members"),
+  maxMembers: z.number().int().min(2, "Minimum 2 members").max(20, "Maximum 20 members"),
   cycleFrequency: z.enum(["weekly", "biweekly", "monthly"]),
+  circleType: z.enum(["public", "private"]).default("public"),
   payoutMethod: z.enum(["fixed", "randomized"]).default("fixed"),
 });
 


### PR DESCRIPTION
## Summary

Resolves #48

## Changes

- Enable `onBlur` validation mode so inline errors appear per-field as users leave each input
- Use `isSubmitting` from react-hook-form to disable the submit button while the request is in flight (removes manual `loading` state)
- Add inline error display for `cycleFrequency` and `circleType` select fields
- Add `.fieldError` CSS class for consistent error styling
- Add `circleType` field and integer constraint on `maxMembers` to `createCircleSchema`

## Acceptance Criteria
- [x] Required fields validated on blur
- [x] Contribution amount must be > 0 (min 10 per schema)
- [x] Max members must be between 2 and 20
- [x] Inline error messages per field
- [x] Submit button disabled while submitting