### PR TITLE
feat: add Stellar wallet connection UI

### DIFF
--- a/src/app/api/stellar/balance/route.ts
+++ b/src/app/api/stellar/balance/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getUsdcBalance } from "@/lib/stellar";
+import type { ApiResponse } from "@/types";
+
+export async function GET(req: NextRequest): Promise<NextResponse<ApiResponse<{ balance: string; hasTrustline: boolean }>>> {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  const publicKey = req.nextUrl.searchParams.get("publicKey");
+  if (!publicKey || !/^G[A-Z2-7]{55}$/.test(publicKey)) {
+    return NextResponse.json({ success: false, error: "Invalid Stellar public key" }, { status: 400 });
+  }
+
+  const data = await getUsdcBalance(publicKey);
+  return NextResponse.json({ success: true, data });
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -4,8 +4,10 @@ import { useState, useEffect } from "react";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import styles from "./page.module.css";
-import type { ProfileData } from "@/app/api/profile/route";
+import type { ProfileData } from "@/app/api/v1/profile/route";
 import type { ReferralData } from "@/app/api/referral/route";
+import { useFreighterWallet } from "@/hooks/useFreighterWallet";
+import { ConnectWalletButton } from "@/components/wallet/ConnectWalletButton";
 
 export default function ProfilePage() {
   const { data: session, status } = useSession();
@@ -18,6 +20,8 @@ export default function ProfilePage() {
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
   const [referral, setReferral] = useState<ReferralData | null>(null);
+  const [stellarKeyError, setStellarKeyError] = useState<string | null>(null);
+  const [usdcBalance, setUsdcBalance] = useState<string | null>(null);
   const [referralCode, setReferralCode] = useState("");
   const [referralMsg, setReferralMsg] = useState<{ type: "success" | "error"; text: string } | null>(null);
   const [applyingCode, setApplyingCode] = useState(false);
@@ -29,7 +33,7 @@ export default function ProfilePage() {
 
   useEffect(() => {
     if (status !== "authenticated") return;
-    fetch("/api/profile")
+    fetch("/api/v1/profile")
       .then((r) => r.json())
       .then((json) => {
         if (json.success) {
@@ -45,6 +49,24 @@ export default function ProfilePage() {
       .then((r) => r.json())
       .then((json) => { if (json.success) setReferral(json.data); });
   }, [status]);
+
+  // Sync Freighter wallet public key into the form field
+  useEffect(() => {
+    if (publicKey) {
+      setForm((f) => ({ ...f, stellarPublicKey: publicKey }));
+      setStellarKeyError(null);
+    }
+  }, [publicKey]);
+
+  // Fetch USDC balance whenever the saved key changes
+  useEffect(() => {
+    const key = profile?.stellarPublicKey;
+    if (!key) { setUsdcBalance(null); return; }
+    fetch(`/api/stellar/balance?publicKey=${encodeURIComponent(key)}`)
+      .then((r) => r.json())
+      .then((json) => { if (json.success) setUsdcBalance(json.data.balance); })
+      .catch(() => {});
+  }, [profile?.stellarPublicKey]);
 
   const handleCopyCode = () => {
     if (!referral?.referralCode) return;
@@ -78,10 +100,16 @@ export default function ProfilePage() {
 
   const handleSave = async (e: React.FormEvent) => {
     e.preventDefault();
+    // Client-side Stellar key validation
+    if (form.stellarPublicKey && !/^G[A-Z2-7]{55}$/.test(form.stellarPublicKey)) {
+      setStellarKeyError("Invalid Stellar public key format (must start with G and be 56 characters)");
+      return;
+    }
+    setStellarKeyError(null);
     setSaving(true);
     setMessage(null);
     try {
-      const res = await fetch("/api/profile", {
+      const res = await fetch("/api/v1/profile", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(form),
@@ -255,7 +283,10 @@ export default function ProfilePage() {
                 id="stellarPublicKey"
                 className="input"
                 value={form.stellarPublicKey}
-                onChange={(e) => setForm((f) => ({ ...f, stellarPublicKey: e.target.value }))}
+                onChange={(e) => {
+                  setForm((f) => ({ ...f, stellarPublicKey: e.target.value }));
+                  setStellarKeyError(null);
+                }}
                 placeholder="GXXXXXXX…"
                 spellCheck={false}
               />
@@ -275,9 +306,19 @@ export default function ProfilePage() {
                   </a>
                 </small>
               )}
+              {stellarKeyError && (
+                <p role="alert" style={{ color: "var(--color-error)", fontSize: "0.875rem", marginTop: "0.25rem" }}>
+                  {stellarKeyError}
+                </p>
+              )}
               {walletError && (
                 <p role="alert" style={{ color: "var(--color-error)", fontSize: "0.875rem", marginTop: "0.25rem" }}>
                   {walletError}
+                </p>
+              )}
+              {profile?.stellarPublicKey && usdcBalance !== null && (
+                <p style={{ color: "var(--color-success)", fontSize: "0.875rem", marginTop: "0.5rem" }}>
+                  Current USDC balance: <strong>{parseFloat(usdcBalance).toFixed(2)} USDC</strong>
                 </p>
               )}
             </div>

--- a/src/components/circle/JoinCircleForm.tsx
+++ b/src/components/circle/JoinCircleForm.tsx
@@ -20,8 +20,20 @@ export function JoinCircleForm({ circle, token, inviteValid }: Props) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [stellarPublicKey, setStellarPublicKey] = useState("");
+  const [noSavedKey, setNoSavedKey] = useState(false);
 
   const { connectionState, publicKey, error: walletError, connect, disconnect } = useFreighterWallet();
+
+  useEffect(() => {
+    // Check if user has a saved Stellar key; show warning if not
+    fetch("/api/v1/profile")
+      .then((r) => r.json())
+      .then((json) => {
+        if (json.success && !json.data.stellarPublicKey) setNoSavedKey(true);
+        if (json.success && json.data.stellarPublicKey) setStellarPublicKey(json.data.stellarPublicKey);
+      })
+      .catch(() => {});
+  }, []);
 
   useEffect(() => {
     if (publicKey !== null) {
@@ -66,6 +78,11 @@ export function JoinCircleForm({ circle, token, inviteValid }: Props) {
 
   return (
     <div className="card">
+      {noSavedKey && (
+        <div role="alert" style={{ background: "rgba(234,179,8,0.1)", border: "1px solid rgba(234,179,8,0.4)", borderRadius: "var(--radius-md)", padding: "var(--space-3) var(--space-4)", marginBottom: "var(--space-4)", fontSize: "0.875rem", color: "var(--color-warning)" }}>
+          ⚠️ You have no Stellar public key saved. Payouts will be sent to the key you enter below. <a href="/profile" style={{ textDecoration: "underline" }}>Save it in your profile</a> to avoid re-entering it each time.
+        </div>
+      )}
       <div className={styles.info}>
         <p>You are joining <strong>{circle.name}</strong>.</p>
         <div className={styles.stats}>


### PR DESCRIPTION
## Summary

Resolves #52

## Changes

- Fix missing `useFreighterWallet` and `ConnectWalletButton` imports in profile page
- Add client-side Stellar public key format validation (regex `/^G[A-Z2-7]{55}$/`) before saving
- Add USDC balance display on profile page when a key is saved
- Add `GET /api/stellar/balance?publicKey=...` route that calls `getUsdcBalance` from the existing Stellar lib
- Pre-populate the Stellar key field in `JoinCircleForm` from the user's saved profile
- Show a warning banner in `JoinCircleForm` when the user has no saved Stellar key, with a link to their profile
- Update profile page to call `/api/v1/profile` directly (the `/api/profile` route is a redirect)

## Acceptance Criteria
- [x] Profile settings page with Stellar key input
- [x] Validate key format before saving
- [x] Show current USDC balance if key is set
- [x] Warning shown if no key set when joining a circle