### PR TITLE
feat: implement optimistic UI updates for join circle

### DIFF
--- a/src/components/circle/JoinCircleForm.module.css
+++ b/src/components/circle/JoinCircleForm.module.css
@@ -73,3 +73,24 @@
   color: var(--color-error);
   font-size: var(--text-sm);
 }
+
+.toast {
+  position: fixed;
+  bottom: var(--space-6);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 9999;
+  padding: var(--space-3) var(--space-5);
+  background: var(--color-error);
+  color: #fff;
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+  white-space: nowrap;
+  animation: fadeInUp 0.2s ease;
+}
+
+@keyframes fadeInUp {
+  from { opacity: 0; transform: translateX(-50%) translateY(8px); }
+  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
+}

--- a/src/components/circle/JoinCircleForm.tsx
+++ b/src/components/circle/JoinCircleForm.tsx
@@ -20,6 +20,7 @@ export function JoinCircleForm({ circle, token, inviteValid }: Props) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [stellarPublicKey, setStellarPublicKey] = useState("");
+  const [optimisticCount, setOptimisticCount] = useState(circle.memberCount ?? 0);
 
   const { connectionState, publicKey, error: walletError, connect, disconnect } = useFreighterWallet();
 
@@ -42,6 +43,9 @@ export function JoinCircleForm({ circle, token, inviteValid }: Props) {
     setLoading(true);
     setError(null);
 
+    // Optimistic update: increment member count immediately
+    setOptimisticCount((c) => c + 1);
+
     try {
       const res = await fetch(`/api/circles/${circle.id}/join`, {
         method: "POST",
@@ -58,6 +62,8 @@ export function JoinCircleForm({ circle, token, inviteValid }: Props) {
       router.push(`/circles/${circle.id}?joined=true`);
       router.refresh();
     } catch (err) {
+      // Revert optimistic update on error
+      setOptimisticCount((c) => c - 1);
       setError(err instanceof Error ? err.message : "Failed to join circle");
     } finally {
       setLoading(false);
@@ -79,6 +85,10 @@ export function JoinCircleForm({ circle, token, inviteValid }: Props) {
           <div className={styles.stat}>
             <span className={styles.statLabel}>Frequency</span>
             <span className={styles.statValue}>{circle.cycleFrequency}</span>
+          </div>
+          <div className={styles.stat}>
+            <span className={styles.statLabel}>Members</span>
+            <span className={styles.statValue}>{optimisticCount} / {circle.maxMembers}</span>
           </div>
         </div>
       </div>
@@ -124,7 +134,11 @@ export function JoinCircleForm({ circle, token, inviteValid }: Props) {
           )}
         </div>
 
-        {error && <div className={styles.error}>{error}</div>}
+        {error && (
+          <div role="alert" className={styles.toast}>
+            {error}
+          </div>
+        )}
 
         <Button
           type="submit"


### PR DESCRIPTION
## Summary

Resolves #60

## Changes

- Add `optimisticCount` state initialised from `circle.memberCount`
- Increment member count immediately when the join button is clicked (before the API responds)
- Revert the count on API error
- Show a toast notification (fixed bottom, slide-up animation) when the join fails
- Display a Members stat (`optimisticCount / maxMembers`) in the join form info section
- The join button already shows a spinner via the `Button loading` prop

## Acceptance Criteria
- [x] Member count increments immediately on join
- [x] Reverts on error with toast notification
- [x] Join button shows spinner during request