### PR TITLE
feat: implement reputation score calculation (#43)

### DIFF
--- a/migrations/1746300000000_add-circle-min-reputation.ts
+++ b/migrations/1746300000000_add-circle-min-reputation.ts
@@ -1,0 +1,15 @@
+import { query } from "@/lib/db";
+
+/**
+ * Add min_reputation column to circles table for reputation gating
+ */
+export async function up(): Promise<void> {
+  await query(`
+    ALTER TABLE circles 
+    ADD COLUMN IF NOT EXISTS min_reputation INTEGER DEFAULT 0 CHECK (min_reputation >= 0 AND min_reputation <= 100)
+  `);
+}
+
+export async function down(): Promise<void> {
+  await query(`ALTER TABLE circles DROP COLUMN IF EXISTS min_reputation`);
+}

--- a/src/app/api/circles/[id]/join/route.ts
+++ b/src/app/api/circles/[id]/join/route.ts
@@ -5,6 +5,7 @@ import { joinCircleSchema } from "@/types/schemas";
 import { joinCircle, getCircleById } from "@/server/services/circle.service";
 import { withErrorHandler } from "@/server/middleware";
 import { verifyInviteToken } from "@/lib/tokens";
+import { checkReputationGate } from "@/server/services/reputation.service";
 import type { ApiResponse, Member } from "@/types";
 
 export const POST = withErrorHandler(async (req: NextRequest, ctx: unknown) => {
@@ -56,6 +57,20 @@ export const POST = withErrorHandler(async (req: NextRequest, ctx: unknown) => {
     const decoded = await verifyInviteToken(token);
     if (decoded && decoded.circleId === params.id) {
       isInvited = true;
+    }
+  }
+
+  // Check reputation gate if circle has minimum reputation requirement
+  if (circle.minReputation && circle.minReputation > 0) {
+    const { eligible, currentScore } = await checkReputationGate(userId, circle.minReputation);
+    if (!eligible) {
+      return NextResponse.json<ApiResponse<never>>(
+        {
+          success: false,
+          error: `This circle requires a minimum reputation score of ${circle.minReputation}. Your current score is ${currentScore}.`,
+        },
+        { status: 403 }
+      );
     }
   }
 

--- a/src/app/api/v1/circles/[id]/join/route.ts
+++ b/src/app/api/v1/circles/[id]/join/route.ts
@@ -5,6 +5,7 @@ import { joinCircleSchema } from "@/types/schemas";
 import { joinCircle, getCircleById } from "@/server/services/circle.service";
 import { withErrorHandler } from "@/server/middleware";
 import { verifyInviteToken } from "@/lib/tokens";
+import { checkReputationGate } from "@/server/services/reputation.service";
 import type { ApiResponse, Member } from "@/types";
 
 export const POST = withErrorHandler(async (req: NextRequest, ctx: unknown) => {
@@ -56,6 +57,20 @@ export const POST = withErrorHandler(async (req: NextRequest, ctx: unknown) => {
     const decoded = await verifyInviteToken(token);
     if (decoded && decoded.circleId === params.id) {
       isInvited = true;
+    }
+  }
+
+  // Check reputation gate if circle has minimum reputation requirement
+  if (circle.minReputation && circle.minReputation > 0) {
+    const { eligible, currentScore } = await checkReputationGate(userId, circle.minReputation);
+    if (!eligible) {
+      return NextResponse.json<ApiResponse<never>>(
+        {
+          success: false,
+          error: `This circle requires a minimum reputation score of ${circle.minReputation}. Your current score is ${currentScore}.`,
+        },
+        { status: 403 }
+      );
     }
   }
 

--- a/src/server/services/dispute.service.ts
+++ b/src/server/services/dispute.service.ts
@@ -79,4 +79,17 @@ export async function confirmContributionFromDispute(
      WHERE id = $3`,
     [disputeId, txHash, contributionId]
   );
+
+  // Get user ID from contribution and increment reputation
+  const { rows } = await query<{ user_id: string }>(
+    `SELECT m.user_id FROM contributions c
+     JOIN members m ON m.id = c.member_id
+     WHERE c.id = $1`,
+    [contributionId]
+  );
+
+  if (rows[0]?.user_id) {
+    const { incrementReputationOnContribution } = await import("./reputation.service");
+    await incrementReputationOnContribution(rows[0].user_id);
+  }
 }

--- a/src/server/services/horizon-stream.service.ts
+++ b/src/server/services/horizon-stream.service.ts
@@ -101,9 +101,7 @@ export function stopHorizonStream(): void {
  * Auto-confirm a contribution when matching USDC payment is received
  * Matches based on amount and timing
  */
-async function autoConfirmContribution(
-  payment: ServerApi.PaymentOperationRecord
-): Promise<void> {
+async function autoConfirmContribution(payment: ServerApi.PaymentOperationRecord): Promise<void> {
   const amountUsdc = payment.amount;
   const txHash = payment.transaction_hash;
   const senderAddress = payment.from;
@@ -146,6 +144,10 @@ async function autoConfirmContribution(
      WHERE id = $2`,
     [txHash, contribution.id]
   );
+
+  // Increment user's reputation score for on-time contribution
+  const { incrementReputationOnContribution } = await import("./reputation.service");
+  await incrementReputationOnContribution(contribution.user_id);
 
   console.log(`[horizon-stream] Auto-confirmed contribution ${contribution.id}`);
 

--- a/src/server/services/reputation.service.ts
+++ b/src/server/services/reputation.service.ts
@@ -1,0 +1,77 @@
+import { query } from "@/lib/db";
+import type { User } from "@/types";
+
+// Score adjustments
+const SCORE_INCREMENT = 5; // Points added on-time contribution
+const SCORE_DECREMENT = 10; // Points deducted on missed contribution
+const MIN_SCORE = 0;
+const MAX_SCORE = 100;
+
+/**
+ * Update user reputation score when a contribution is confirmed.
+ * Called after successful payment confirmation.
+ */
+export async function incrementReputationOnContribution(userId: string): Promise<number> {
+  const { rows } = await query<{ reputation_score: number }>(
+    `UPDATE users 
+     SET reputation_score = LEAST(reputation_score + $1, $2)
+     WHERE id = $3
+     RETURNING reputation_score`,
+    [SCORE_INCREMENT, MAX_SCORE, userId]
+  );
+
+  return rows[0]?.reputation_score ?? 0;
+}
+
+/**
+ * Update user reputation score when a contribution is missed/defaulted.
+ * Called when processing missed contributions.
+ */
+export async function decrementReputationOnMissedContribution(userId: string): Promise<number> {
+  const { rows } = await query<{ reputation_score: number }>(
+    `UPDATE users 
+     SET reputation_score = GREATEST(reputation_score - $1, $2)
+     WHERE id = $3
+     RETURNING reputation_score`,
+    [SCORE_DECREMENT, MIN_SCORE, userId]
+  );
+
+  return rows[0]?.reputation_score ?? 0;
+}
+
+/**
+ * Get user's current reputation score.
+ */
+export async function getUserReputation(userId: string): Promise<number> {
+  const { rows } = await query<{ reputation_score: number }>(
+    `SELECT reputation_score FROM users WHERE id = $1`,
+    [userId]
+  );
+
+  return rows[0]?.reputation_score ?? 0;
+}
+
+/**
+ * Check if user meets the minimum reputation requirement for a circle.
+ */
+export async function checkReputationGate(
+  userId: string,
+  requiredScore: number
+): Promise<{ eligible: boolean; currentScore: number }> {
+  const currentScore = await getUserReputation(userId);
+
+  return {
+    eligible: currentScore >= requiredScore,
+    currentScore,
+  };
+}
+
+/**
+ * Calculate reputation level label based on score.
+ */
+export function getReputationLevel(score: number): string {
+  if (score >= 80) return "Excellent";
+  if (score >= 60) return "Good";
+  if (score >= 40) return "Fair";
+  return "Building";
+}

--- a/src/server/services/scheduler.service.ts
+++ b/src/server/services/scheduler.service.ts
@@ -1,5 +1,9 @@
 import { query } from "@/lib/db";
-import { notifyPayoutReminder, notifyMissedContribution, notifyContributionReminder } from "./notification.service";
+import {
+  notifyPayoutReminder,
+  notifyMissedContribution,
+  notifyContributionReminder,
+} from "./notification.service";
 import { getMissedContributions } from "./contribution.service";
 import type { Circle, Member } from "@/types";
 
@@ -32,18 +36,17 @@ export async function sendPayoutReminders(): Promise<void> {
       if (!recipient) continue;
 
       const totalPot = (
-        parseFloat(circle.contributionUsdc) * 
-        (await query<Member>("SELECT COUNT(*) as count FROM members WHERE circle_id = $1 AND status = 'active'", [circle.id]))
-          .rows[0]?.count || 0
+        parseFloat(circle.contributionUsdc) *
+          (
+            await query<Member>(
+              "SELECT COUNT(*) as count FROM members WHERE circle_id = $1 AND status = 'active'",
+              [circle.id]
+            )
+          ).rows[0]?.count || 0
       ).toFixed(7);
 
       // Send reminder to recipient
-      await notifyPayoutReminder(
-        recipient.userId,
-        circle.name,
-        totalPot,
-        24
-      );
+      await notifyPayoutReminder(recipient.userId, circle.name, totalPot, 24);
     } catch (error) {
       console.error(`Failed to send payout reminder for circle ${circle.id}:`, error);
     }
@@ -69,10 +72,7 @@ export async function processMissedContributions(): Promise<void> {
 
       for (const { memberId, userId } of missed) {
         // Mark member as defaulted
-        await query(
-          "UPDATE members SET status = 'defaulted' WHERE id = $1",
-          [memberId]
-        );
+        await query("UPDATE members SET status = 'defaulted' WHERE id = $1", [memberId]);
 
         // Create missed contribution record
         await query(
@@ -81,6 +81,10 @@ export async function processMissedContributions(): Promise<void> {
            ON CONFLICT (member_id, cycle_number) DO NOTHING`,
           [circle.id, memberId, circle.currentCycle, circle.contributionUsdc]
         );
+
+        // Decrement user's reputation score for missed contribution
+        const { decrementReputationOnMissedContribution } = await import("./reputation.service");
+        await decrementReputationOnMissedContribution(userId);
 
         // Send notification
         await notifyMissedContribution(userId, circle.name, circle.contributionUsdc);
@@ -94,8 +98,8 @@ export async function processMissedContributions(): Promise<void> {
 type ReminderWindow = { hoursLeft: number; lowerBound: string; upperBound: string };
 
 const WINDOWS: ReminderWindow[] = [
-  { hoursLeft: 24, lowerBound: '23 hours', upperBound: '25 hours' },
-  { hoursLeft: 2,  lowerBound: '1 hour',   upperBound: '3 hours'  },
+  { hoursLeft: 24, lowerBound: "23 hours", upperBound: "25 hours" },
+  { hoursLeft: 2, lowerBound: "1 hour", upperBound: "3 hours" },
 ];
 
 /**
@@ -147,7 +151,7 @@ export async function sendContributionReminders(): Promise<void> {
                AND cycle_number = $3`,
             [member.id, circle.id, circle.currentCycle]
           );
-          if (statusRows.length > 0 && statusRows[0].status === 'missed') continue;
+          if (statusRows.length > 0 && statusRows[0].status === "missed") continue;
 
           // Check idempotency — has this reminder already been sent?
           const { rows: reminderRows } = await query(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,8 +24,8 @@ export interface Circle {
   id: string;
   name: string;
   creatorId: string;
-  contributionUsdc: string;   // per-member per-cycle amount
-  contributionFiat: number;   // renamed from contributionNgn
+  contributionUsdc: string; // per-member per-cycle amount
+  contributionFiat: number; // renamed from contributionNgn
   contributionCurrency: SupportedCurrency;
   circleType: CircleType;
   maxMembers: number;
@@ -33,10 +33,11 @@ export interface Circle {
   payoutMethod: PayoutMethod;
   randomizationSeed?: string; // stored seed for verifiability
   status: CircleStatus;
-  contractId?: string;        // deployed Soroban circle contract
-  currentCycle: number;       // 1-indexed
-  memberCount?: number;       // calculated field
+  contractId?: string; // deployed Soroban circle contract
+  currentCycle: number; // 1-indexed
+  memberCount?: number; // calculated field
   nextPayoutAt?: Date;
+  minReputation?: number; // minimum reputation score required to join (0-100)
   createdAt: Date;
   updatedAt: Date;
 }
@@ -48,11 +49,11 @@ export interface Member {
   id: string;
   circleId: string;
   userId: string;
-  position: number | null;    // payout order (1 = first to receive), null for pending members
+  position: number | null; // payout order (1 = first to receive), null for pending members
   status: MemberStatus;
   hasReceivedPayout: boolean;
   joinedAt: Date;
-  reviewedAt?: Date;          // when creator approved/rejected the request
+  reviewedAt?: Date; // when creator approved/rejected the request
 }
 
 // ─── Contribution ─────────────────────────────────────────────────────────────
@@ -86,9 +87,9 @@ export interface CircleMessage {
   id: string;
   circleId: string;
   userId: string;
-  displayName: string;  // joined from users table at read time
+  displayName: string; // joined from users table at read time
   content: string;
-  createdAt: string;    // ISO 8601 string
+  createdAt: string; // ISO 8601 string
 }
 
 // ─── API ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #43

---

feat: implement reputation score calculation (#43)

### Summary
Implements the reputation score system for issue #43. `User.reputationScore` is now automatically updated based on contribution behavior.

### Changes

| File | Change |
|------|--------|
| `src/server/services/reputation.service.ts` | New service with score increment (+5), decrement (-10), and gate check |
| `src/types/index.ts` | Added `minReputation?: number` to Circle interface |
| `src/server/services/horizon-stream.service.ts` | Increment score on payment confirmation |
| `src/server/services/dispute.service.ts` | Increment score on dispute resolution |
| `src/server/services/scheduler.service.ts` | Decrement score on missed/defaulted contributions |
| `src/app/api/circles/[id]/join/route.ts` | Reputation gate check (legacy + v1) |
| `migrations/1746300000000_add-circle-min-reputation.ts` | DB migration for `min_reputation` column |

### Behavior
- **+5 points** when a contribution is confirmed (on-time payment)
- **-10 points** when a contribution is missed/defaulted
- **Score clamped** between 0–100
- **Circle gating:** Creators can set `minReputation` (0-100) to restrict who can join
- **Profile display:** Already exists — shows score with labels (Excellent/Good/Fair/Building)

### Acceptance Criteria
- [x] Score incremented on confirmed contribution
- [x] Score decremented on missed contribution  
- [x] Score visible on user profile
- [x] Score used to gate joining high-value circles