### PR TITLE
feat(db): soft delete circles with deletedAt timestamp

### DIFF
--- a/migrations/1746400000000_add-soft-delete-circles.ts
+++ b/migrations/1746400000000_add-soft-delete-circles.ts
@@ -1,0 +1,13 @@
+import { MigrationBuilder } from "node-pg-migrate";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumn("circles", {
+    deleted_at: { type: "timestamp", default: null },
+  });
+  pgm.createIndex("circles", "deleted_at");
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex("circles", "deleted_at");
+  pgm.dropColumn("circles", "deleted_at");
+}

--- a/src/app/api/admin/circles/route.ts
+++ b/src/app/api/admin/circles/route.ts
@@ -1,12 +1,13 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { adminListCircles } from "@/server/services/admin.service";
 import { withAdminAuth, withErrorHandler } from "@/server/middleware";
 import type { ApiResponse } from "@/types";
 import type { AdminCircleRow } from "@/server/services/admin.service";
 
 export const GET = withErrorHandler(
-  withAdminAuth(async () => {
-    const circles = await adminListCircles();
+  withAdminAuth(async (req: NextRequest) => {
+    const includeDeleted = new URL(req.url).searchParams.get("includeDeleted") === "true";
+    const circles = await adminListCircles(includeDeleted);
     return NextResponse.json<ApiResponse<AdminCircleRow[]>>({ success: true, data: circles });
   })
 );

--- a/src/server/services/admin.service.ts
+++ b/src/server/services/admin.service.ts
@@ -12,8 +12,9 @@ export interface AdminPayoutRow extends Payout {
 
 /**
  * List all circles with their current member count.
+ * Pass includeDeleted=true to also return soft-deleted circles.
  */
-export async function adminListCircles(): Promise<AdminCircleRow[]> {
+export async function adminListCircles(includeDeleted = false): Promise<AdminCircleRow[]> {
   const { rows } = await query<AdminCircleRow>(
     `SELECT
        c.id, c.name, c.creator_id as "creatorId",
@@ -28,9 +29,11 @@ export async function adminListCircles(): Promise<AdminCircleRow[]> {
        c.next_payout_at as "nextPayoutAt",
        c.created_at as "createdAt",
        c.updated_at as "updatedAt",
+       c.deleted_at as "deletedAt",
        COUNT(m.id)::int AS "memberCount"
      FROM circles c
      LEFT JOIN members m ON m.circle_id = c.id
+     ${includeDeleted ? "" : "WHERE c.deleted_at IS NULL"}
      GROUP BY c.id
      ORDER BY c.created_at DESC`
   );

--- a/src/server/services/circle.service.ts
+++ b/src/server/services/circle.service.ts
@@ -28,7 +28,8 @@ const CIRCLE_SELECT = `
   (SELECT COUNT(*)::int FROM members WHERE circle_id = circles.id AND status = 'active') as "memberCount",
   next_payout_at as "nextPayoutAt", 
   created_at as "createdAt", 
-  updated_at as "updatedAt"
+  updated_at as "updatedAt",
+  deleted_at as "deletedAt"
 `;
 
 const MEMBER_SELECT = `
@@ -66,7 +67,7 @@ export async function createCircle(
 
 export async function getCircleById(id: string): Promise<Circle | null> {
   const { rows } = await query<Circle>(
-    `SELECT ${CIRCLE_SELECT} FROM circles WHERE id = $1`,
+    `SELECT ${CIRCLE_SELECT} FROM circles WHERE id = $1 AND deleted_at IS NULL`,
     [id]
   );
   return rows[0] ?? null;
@@ -96,8 +97,8 @@ export async function listOpenCircles(
   const safeLimit = Math.min(100, Math.max(1, limit));
   const offset = (safePage - 1) * safeLimit;
 
-  let queryText = `SELECT ${CIRCLE_SELECT} FROM circles WHERE status = 'open'`;
-  let countQueryText = "SELECT COUNT(*) FROM circles WHERE status = 'open'";
+  let queryText = `SELECT ${CIRCLE_SELECT} FROM circles WHERE status = 'open' AND deleted_at IS NULL`;
+  let countQueryText = "SELECT COUNT(*) FROM circles WHERE status = 'open' AND deleted_at IS NULL";
   const queryParams: any[] = [];
   let paramIndex = 1;
 
@@ -165,7 +166,7 @@ export async function getCirclesByUser(userId: string): Promise<Circle[]> {
         c.updated_at as "updatedAt"
      FROM circles c
      LEFT JOIN members m ON m.circle_id = c.id
-     WHERE c.creator_id = $1 OR m.user_id = $1
+     WHERE (c.creator_id = $1 OR m.user_id = $1) AND c.deleted_at IS NULL
      ORDER BY c.created_at DESC`,
     [userId]
   );
@@ -602,4 +603,19 @@ export async function leaveCircle(
       );
     }
   });
+}
+
+/**
+ * Soft-delete a circle by setting deleted_at.
+ * Only the creator or an admin can delete. Deleted circles are hidden from all
+ * public queries but remain in the database for historical reference.
+ */
+export async function deleteCircle(circleId: string, requesterId: string, isAdmin = false): Promise<void> {
+  const { rows } = await query<{ creator_id: string }>(
+    "SELECT creator_id FROM circles WHERE id = $1 AND deleted_at IS NULL",
+    [circleId]
+  );
+  if (!rows[0]) throw new Error("Circle not found");
+  if (!isAdmin && rows[0].creator_id !== requesterId) throw new Error("Only the creator can delete this circle");
+  await query("UPDATE circles SET deleted_at = NOW(), updated_at = NOW() WHERE id = $1", [circleId]);
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,6 +41,7 @@ export interface Circle {
   minReputation?: number; // minimum reputation score required to join (0-100)
   createdAt: Date;
   updatedAt: Date;
+  deletedAt?: Date | null; // soft delete timestamp
 }
 
 // ─── Membership ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
- Add migration: deleted_at column + index on circles table
- deleteCircle() sets deleted_at=NOW() instead of hard delete
- All public queries filter WHERE deleted_at IS NULL
- adminListCircles() accepts includeDeleted param to view soft-deleted circles
- Admin API GET /api/admin/circles?includeDeleted=true exposes deleted circles
- Circle type includes deletedAt?: Date | null field

Closes #45

## Summary

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs
- [ ] Smart contract change


## Checklist
- [ ] Tests pass (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Types pass (`npm run type-check`)
- [ ] Contract tests pass (`npm run contract:test`) if applicable
- [ ] No secrets committed
