### PR TITLE
Feat/issue 248 circle search filter

### DIFF
--- a/contracts/ajo/src/integration_tests.rs
+++ b/contracts/ajo/src/integration_tests.rs
@@ -284,6 +284,86 @@ mod integration {
         assert!(!completed);
     }
 
+    // ─── Upgrade tests ────────────────────────────────────────────────────────
+
+    /// upgrade: admin can upgrade the contract WASM and event is emitted
+    #[test]
+    fn test_upgrade_emits_event() {
+        use soroban_sdk::{testutils::Events, BytesN, TryFromVal};
+
+        let f = setup_fixture(2);
+        let new_wasm_hash = BytesN::from_array(&f.env, &[1u8; 32]);
+
+        f.client.upgrade(&new_wasm_hash);
+
+        let upgraded_sym = soroban_sdk::Symbol::new(&f.env, "upgraded");
+        let found = f.env.events().all().iter().any(|(_, topics, data)| {
+            if topics.len() != 1 {
+                return false;
+            }
+            let Ok(sym) = soroban_sdk::Symbol::try_from_val(&f.env, &topics.get(0).unwrap()) else {
+                return false;
+            };
+            if sym != upgraded_sym {
+                return false;
+            }
+            let Ok(hash) = BytesN::<32>::try_from_val(&f.env, data) else {
+                return false;
+            };
+            hash == new_wasm_hash
+        });
+
+        assert!(found, "upgraded event should be emitted with the new wasm hash");
+    }
+
+    /// upgrade: non-admin cannot upgrade (wrong auth → panics)
+    #[test]
+    #[should_panic]
+    fn test_upgrade_non_admin_panics() {
+        use soroban_sdk::{
+            testutils::{MockAuth, MockAuthInvoke},
+            BytesN, IntoVal,
+        };
+
+        let f = setup_fixture(2);
+        let non_admin = Address::generate(&f.env);
+        let new_wasm_hash = BytesN::from_array(&f.env, &[2u8; 32]);
+
+        // Authorize as non_admin instead of the real admin — should fail
+        f.env.mock_auths(&[MockAuth {
+            address: &non_admin,
+            invoke: &MockAuthInvoke {
+                contract: &f.client.address,
+                fn_name: "upgrade",
+                args: (new_wasm_hash.clone(),).into_val(&f.env),
+                sub_invokes: &[],
+            },
+        }]);
+
+        f.client.upgrade(&new_wasm_hash);
+    }
+
+    /// upgrade: state is preserved after upgrade call
+    #[test]
+    fn test_upgrade_preserves_state() {
+        use soroban_sdk::BytesN;
+
+        let f = setup_fixture(2);
+
+        // Join one member to set some state
+        f.client.join(&f.members.get(0).unwrap());
+
+        let (cycle_before, max_before, _, completed_before) = f.client.get_state();
+
+        let new_wasm_hash = BytesN::from_array(&f.env, &[3u8; 32]);
+        f.client.upgrade(&new_wasm_hash);
+
+        let (cycle_after, max_after, _, completed_after) = f.client.get_state();
+        assert_eq!(cycle_before, cycle_after, "cycle should be unchanged after upgrade");
+        assert_eq!(max_before, max_after, "max_members should be unchanged after upgrade");
+        assert_eq!(completed_before, completed_after, "completed flag should be unchanged after upgrade");
+    }
+
     /// Pot distribution: each member ends up net-positive after receiving payout
     #[test]
     fn test_net_positive_for_all_members() {

--- a/src/app/api/v1/circles/route.ts
+++ b/src/app/api/v1/circles/route.ts
@@ -32,6 +32,7 @@ export const GET = withErrorHandler(async (req: NextRequest) => {
   const maxAmount = searchParams.get("maxAmount") ? parseInt(searchParams.get("maxAmount")!, 10) : undefined;
   const currency = searchParams.get("currency") ?? undefined;
   const search = searchParams.get("search") ?? undefined;
+  const status = searchParams.get("status") as any ?? undefined;
 
   const result = await listOpenCircles(page, limit, {
     frequency,
@@ -39,6 +40,7 @@ export const GET = withErrorHandler(async (req: NextRequest) => {
     maxAmount,
     currency,
     search,
+    status,
   });
   return NextResponse.json<ApiResponse<PaginatedCircles>>({ success: true, data: result });
 });

--- a/src/app/circles/page.tsx
+++ b/src/app/circles/page.tsx
@@ -14,6 +14,8 @@ interface Props {
     minAmount?: string;
     maxAmount?: string;
     search?: string;
+    status?: string;
+    currency?: string;
   };
 }
 
@@ -24,13 +26,17 @@ export default async function CirclesPage({ searchParams }: Props) {
     minAmount: searchParams.minAmount ? parseInt(searchParams.minAmount, 10) : undefined,
     maxAmount: searchParams.maxAmount ? parseInt(searchParams.maxAmount, 10) : undefined,
     search: searchParams.search,
+    status: searchParams.status as any,
+    currency: searchParams.currency,
   });
 
   return (
     <div className={styles.page}>
       <div className="container">
         <div className={styles.header}>
-          <h1 className={styles.title}>Open Circles</h1>
+          <h1 className={styles.title}>
+            {searchParams.status ? `${searchParams.status.charAt(0).toUpperCase() + searchParams.status.slice(1)} Circles` : 'Open Circles'}
+          </h1>
           <Link href="/circles/create" className="btn btn--accent">+ New Circle</Link>
         </div>
 

--- a/src/components/circle/CircleFilters.tsx
+++ b/src/components/circle/CircleFilters.tsx
@@ -15,6 +15,7 @@ export function CircleFilters() {
   const [minAmount, setMinAmount] = useState(searchParams.get("minAmount") || "");
   const [maxAmount, setMaxAmount] = useState(searchParams.get("maxAmount") || "");
   const [currency, setCurrency] = useState(searchParams.get("currency") || "");
+  const [status, setStatus] = useState(searchParams.get("status") || "");
 
   const updateFilters = useCallback(
     (newFilters: Record<string, string>) => {
@@ -70,6 +71,24 @@ export function CircleFilters() {
           <option value="weekly">Weekly</option>
           <option value="biweekly">Bi-weekly</option>
           <option value="monthly">Monthly</option>
+        </select>
+      </div>
+
+      <div className={styles.filterGroup}>
+        <label className={styles.label}>Status</label>
+        <select
+          className={styles.select}
+          value={status}
+          onChange={(e) => {
+            setStatus(e.target.value);
+            updateFilters({ status: e.target.value });
+          }}
+        >
+          <option value="">All Statuses</option>
+          <option value="open">Open</option>
+          <option value="active">Active</option>
+          <option value="completed">Completed</option>
+          <option value="cancelled">Cancelled</option>
         </select>
       </div>
 

--- a/src/server/services/circle.service.ts
+++ b/src/server/services/circle.service.ts
@@ -86,6 +86,7 @@ export interface CircleFilters {
   maxAmount?: number;
   currency?: string;
   search?: string;
+  status?: CircleStatus;
 }
 
 export async function listOpenCircles(
@@ -97,10 +98,12 @@ export async function listOpenCircles(
   const safeLimit = Math.min(100, Math.max(1, limit));
   const offset = (safePage - 1) * safeLimit;
 
-  let queryText = `SELECT ${CIRCLE_SELECT} FROM circles WHERE status = 'open' AND deleted_at IS NULL`;
-  let countQueryText = "SELECT COUNT(*) FROM circles WHERE status = 'open' AND deleted_at IS NULL";
-  const queryParams: any[] = [];
-  let paramIndex = 1;
+  const statusFilter: CircleStatus = filters.status ?? 'open';
+  const queryParams: any[] = [statusFilter];
+  let paramIndex = 2;
+
+  let queryText = `SELECT ${CIRCLE_SELECT} FROM circles WHERE status = $1 AND deleted_at IS NULL`;
+  let countQueryText = "SELECT COUNT(*) FROM circles WHERE status = $1 AND deleted_at IS NULL";
 
   if (filters.frequency) {
     queryText += ` AND cycle_frequency = $${paramIndex}`;


### PR DESCRIPTION
  Here's a PR description for issue #248:
  
  ──────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Add circle search and filter on browse page
  
  Closes #248 
  
  What changed
  
  The browse page already had a CircleFilters component and the service/API already supported search,
  frequency, and amount range — but the status filter was missing end-to-end (hardcoded to 'open' in the DB
  query).
  
  - circle.service.ts — added status?: CircleStatus to CircleFilters; replaced hardcoded WHERE status =
  'open' with a parameterized query defaulting to 'open'
  - api/v1/circles/route.ts — reads and forwards status query param
  - circles/page.tsx — added status and currency to searchParams; dynamic page title reflects active filter
  - CircleFilters.tsx — added Status dropdown (open / active / completed / cancelled) with URL sync
  
  How filters work
  
  All filters (search, frequency, status, amount range, currency) update URL query params on change and are
  read server-side on page load — no client-side filtering.
  
  Testing
  
  - Browse /circles — defaults to open circles as before
  - Select a status → URL updates, page re-renders with filtered results
  - Search by name → debounced, reflected in URL after 500ms
  - Clear all filters → /circles resets to defaults

