### PR TITLE
ci: add Node 20 and 22 matrix to lint, test, and build jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,24 +12,32 @@ concurrency:
 
 jobs:
   lint-and-type-check:
-    name: Lint & Type Check
+    name: Lint & Type Check (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: 20, cache: npm }
+        with: { node-version: "${{ matrix.node-version }}", cache: npm }
       - run: npm ci
       - run: npm run lint
       - run: npm run type-check
       - run: npm run format:check
 
   test:
-    name: Unit Tests
+    name: Unit Tests (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: 20, cache: npm }
+        with: { node-version: "${{ matrix.node-version }}", cache: npm }
       - run: npm ci
       - name: Run tests with coverage
         run: npm run test:coverage -- --ci
@@ -43,9 +51,13 @@ jobs:
           verbose: true
 
   build:
-    name: Next.js Build
+    name: Next.js Build (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     needs: [lint-and-type-check]
+    strategy:
+      fail-fast: true
+      matrix:
+        node-version: [20, 22]
     env:
       NEXT_PUBLIC_APP_URL: http://localhost:3000
       NEXT_PUBLIC_APP_NAME: Ajosave
@@ -69,7 +81,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: 20, cache: npm }
+        with: { node-version: "${{ matrix.node-version }}", cache: npm }
       - run: npm ci
       - run: npm run build
 


### PR DESCRIPTION
- lint-and-type-check, test, and build jobs now run on both Node 20 and 22
- fail-fast: true ensures a failing matrix job blocks the PR
- migrate-ci and e2e remain on Node 20 (infrastructure/browser tests, not Node compatibility)

Closes #272
Closes #267 

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs
- [ ] Smart contract change

## Related issues
Closes #

## Checklist
- [ ] Tests pass (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Types pass (`npm run type-check`)
- [ ] Contract tests pass (`npm run contract:test`) if applicable
- [ ] No secrets committed
