### PR TITLE
feat: add multi-member integration test and explicit CI sandbox step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,9 +158,12 @@ jobs:
       - name: Run contract unit tests
         working-directory: contracts
         run: cargo test --lib
-      - name: Run Soroban integration tests
+      - name: Run Soroban integration tests (local sandbox)
+        # Uses soroban-sdk testutils in-process sandbox — no external node required.
+        # Covers: initialize → join → contribute → payout full lifecycle,
+        # multi-member (5-member) scenario, edge cases, and upgrade tests.
         working-directory: contracts
-        run: cargo test integration_tests
+        run: cargo test integration_tests -- --test-threads=4
 
   deploy-contract-testnet:
     name: Deploy Contract to Testnet

--- a/contracts/ajo/src/integration_tests.rs
+++ b/contracts/ajo/src/integration_tests.rs
@@ -364,6 +364,53 @@ mod integration {
         assert_eq!(completed_before, completed_after, "completed flag should be unchanged after upgrade");
     }
 
+    /// Multi-member scenario: 5-member circle completes full rotation
+    #[test]
+    fn test_multi_member_five_members() {
+        let f = setup_fixture(5);
+        let Fixture { env, members, token, client, contribution, max_members, interval, .. } = &f;
+
+        // All 5 members join
+        for m in members.iter() {
+            client.join(m);
+        }
+
+        let (cycle, max, _, completed) = client.get_state();
+        assert_eq!(cycle, 1);
+        assert_eq!(max, 5);
+        assert!(!completed);
+        assert_eq!(client.get_members().len(), 5);
+
+        let mut timestamp: u64 = 0;
+        for cycle_num in 1..=*max_members {
+            timestamp += interval + 1;
+            env.ledger().with_mut(|l| l.timestamp = timestamp);
+
+            let recipient = members.get(cycle_num - 1).unwrap();
+            let before = token.balance(&recipient);
+            client.payout();
+            let after = token.balance(&recipient);
+
+            assert_eq!(
+                after - before,
+                contribution * (*max_members as i128),
+                "cycle {cycle_num}: 5-member pot should be 5× contribution"
+            );
+
+            if cycle_num < *max_members {
+                let (current, _, _, done) = client.get_state();
+                assert_eq!(current, cycle_num + 1);
+                assert!(!done);
+                for m in members.iter() {
+                    client.contribute(m);
+                }
+            }
+        }
+
+        let (_, _, _, completed) = client.get_state();
+        assert!(completed, "5-member circle should complete after 5 payouts");
+    }
+
     /// Pot distribution: each member ends up net-positive after receiving payout
     #[test]
     fn test_net_positive_for_all_members() {


### PR DESCRIPTION
- Add test_multi_member_five_members: full 5-member circle lifecycle using soroban-sdk in-process sandbox (no external node required)
- Update CI contract-test step with --test-threads=4 and descriptive comment documenting sandbox usage and test coverage

Closes #349
Closes #350 
Closes #351 
Closes #352 


## Summary

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs
- [ ] Smart contract change

#

## Checklist
- [ ] Tests pass (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Types pass (`npm run type-check`)
- [ ] Contract tests pass (`npm run contract:test`) if applicable
- [ ] No secrets committed
