### PR TITLE
feat: post-deploy contract verification script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,3 +190,14 @@ jobs:
         run: npm run contract:deploy
       - name: Print contract ID
         run: cat .contract-id
+      - name: Verify deployed contract
+        env:
+          STELLAR_NETWORK: testnet
+          STELLAR_SERVER_SECRET_KEY: ${{ secrets.STELLAR_TESTNET_SECRET_KEY }}
+        run: npm run contract:verify
+      - name: Upload deploy artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: contract-deploy-artifacts
+          path: deploy-artifacts/
+          retention-days: 30

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "contract:build": "cd contracts && stellar contract build",
     "contract:test": "cd contracts && cargo test",
     "contract:deploy": "ts-node scripts/deploy-contract.ts",
+    "contract:verify": "ts-node scripts/verify-contract.ts",
     "migrate": "ts-node scripts/migrate.ts up",
     "migrate:down": "ts-node scripts/migrate.ts down",
     "migrate:create": "node-pg-migrate create --migrations-dir migrations",

--- a/scripts/verify-contract.ts
+++ b/scripts/verify-contract.ts
@@ -1,0 +1,86 @@
+#!/usr/bin/env ts-node
+/**
+ * Post-deploy contract verification (Issue #350)
+ *
+ * Calls get_state() on the deployed Ajo contract and verifies it returns
+ * a valid response. Fails with exit code 1 if the contract is unresponsive.
+ * Runs for both testnet and mainnet based on STELLAR_NETWORK env var.
+ */
+import { execSync } from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+
+const network = process.env.STELLAR_NETWORK ?? "testnet";
+const isTestnet = network !== "mainnet";
+
+const rpcUrl = isTestnet
+  ? "https://soroban-testnet.stellar.org"
+  : "https://soroban-rpc.stellar.org";
+const passphrase = isTestnet
+  ? "Test SDF Network ; September 2015"
+  : "Public Global Stellar Network ; September 2015";
+
+// Resolve contract ID: prefer env var, fall back to .contract-id file
+let contractId = process.env.STELLAR_AJO_CONTRACT_ID ?? "";
+if (!contractId) {
+  const idFile = path.resolve(__dirname, "../.contract-id");
+  if (fs.existsSync(idFile)) {
+    contractId = fs.readFileSync(idFile, "utf-8").trim();
+  }
+}
+
+if (!contractId) {
+  console.error("❌ No contract ID found. Set STELLAR_AJO_CONTRACT_ID or run deploy first.");
+  process.exit(1);
+}
+
+const sourceKey = process.env.STELLAR_SERVER_SECRET_KEY;
+if (!sourceKey) {
+  console.error("❌ STELLAR_SERVER_SECRET_KEY is not set.");
+  process.exit(1);
+}
+
+console.log(`\n🔍 Verifying Ajo contract on ${network}`);
+console.log(`   Contract ID : ${contractId}`);
+console.log(`   RPC URL     : ${rpcUrl}\n`);
+
+try {
+  const output = execSync(
+    `stellar contract invoke \
+      --id ${contractId} \
+      --source ${sourceKey} \
+      --rpc-url ${rpcUrl} \
+      --network-passphrase "${passphrase}" \
+      -- get_state`,
+    { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }
+  );
+
+  const raw = output.trim();
+  console.log(`   get_state() response: ${raw}`);
+
+  // get_state returns a tuple: (current_cycle, max_members, next_payout_time, completed)
+  // Any non-empty response means the contract is alive and responding.
+  if (!raw) {
+    throw new Error("get_state() returned empty response");
+  }
+
+  // Log contract ID to deploy artifacts
+  const artifactsDir = path.resolve(__dirname, "../deploy-artifacts");
+  if (!fs.existsSync(artifactsDir)) fs.mkdirSync(artifactsDir, { recursive: true });
+
+  const artifact = {
+    contractId,
+    network,
+    verifiedAt: new Date().toISOString(),
+    getStateResponse: raw,
+  };
+  const artifactPath = path.join(artifactsDir, `contract-${network}.json`);
+  fs.writeFileSync(artifactPath, JSON.stringify(artifact, null, 2));
+
+  console.log(`\n✅ Contract verified successfully`);
+  console.log(`   Artifact written to: ${artifactPath}`);
+} catch (err: unknown) {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`\n❌ Contract verification failed: ${message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
- Add scripts/verify-contract.ts: calls get_state() on deployed contract, fails with exit 1 if unresponsive, writes deploy-artifacts/contract-{network}.json
- Works for both testnet and mainnet via STELLAR_NETWORK env var
- Reads contract ID from STELLAR_AJO_CONTRACT_ID or .contract-id file
- Add contract:verify npm script
- CI: run verification after deploy and upload artifacts (30-day retention)

Closes #350

## Summary

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs
- [ ] Smart contract change


## Checklist
- [ ] Tests pass (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Types pass (`npm run type-check`)
- [ ] Contract tests pass (`npm run contract:test`) if applicable
- [ ] No secrets committed
