### PR TITLE
feat: implement WalletConnect support for mobile Stellar wallets

### DIFF
--- a/src/components/wallet/WalletConnectButton.module.css
+++ b/src/components/wallet/WalletConnectButton.module.css
@@ -1,0 +1,66 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.connected {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--color-surface, #1e293b);
+  border: 1px solid var(--color-border, #334155);
+  border-radius: 8px;
+}
+
+.wallet {
+  font-size: 0.875rem;
+  color: var(--color-text, #f8fafc);
+}
+
+.error {
+  font-size: 0.875rem;
+  color: var(--color-error, #f87171);
+  margin: 0;
+}
+
+.pairing {
+  margin-top: 0.5rem;
+}
+
+.qr {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1.5rem;
+  background: var(--color-surface, #1e293b);
+  border: 1px solid var(--color-border, #334155);
+  border-radius: 12px;
+}
+
+.qrLabel {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--color-text, #f8fafc);
+  margin: 0;
+}
+
+.qrHint {
+  font-size: 0.8rem;
+  color: var(--color-muted, #94a3b8);
+  margin: 0;
+  text-align: center;
+}
+
+.deepLink {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  background: var(--color-accent, #6366f1);
+  color: #fff;
+  border-radius: 8px;
+  text-decoration: none;
+  font-weight: 600;
+}

--- a/src/components/wallet/WalletConnectButton.tsx
+++ b/src/components/wallet/WalletConnectButton.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useWalletConnect } from "@/hooks/useWalletConnect";
+import { Button } from "@/components/ui/Button";
+import styles from "./WalletConnectButton.module.css";
+
+/**
+ * WalletConnectButton
+ *
+ * - Desktop: shows QR code for scanning with LOBSTR / xBull mobile app
+ * - Mobile: shows a deep link button to open the wallet directly
+ * - Session persists across page refreshes via localStorage
+ * - Disconnect clears the session
+ */
+export function WalletConnectButton() {
+  const { session, pairingUri, loading, error, connect, disconnect } = useWalletConnect();
+  const [isMobile, setIsMobile] = useState(false);
+  const [QRCode, setQRCode] = useState<React.ComponentType<{ value: string; size: number }> | null>(null);
+
+  useEffect(() => {
+    setIsMobile(/Mobi|Android|iPhone/i.test(navigator.userAgent));
+  }, []);
+
+  // Dynamically load QR code renderer only on desktop when needed
+  useEffect(() => {
+    if (pairingUri && !isMobile) {
+      import("qrcode.react").then((mod) => setQRCode(() => mod.QRCodeSVG));
+    }
+  }, [pairingUri, isMobile]);
+
+  if (session) {
+    return (
+      <div className={styles.connected}>
+        <span className={styles.wallet}>
+          🔗 {session.walletName} · {session.publicKey.slice(0, 6)}…{session.publicKey.slice(-4)}
+        </span>
+        <Button variant="ghost" size="sm" onClick={disconnect}>
+          Disconnect
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.container}>
+      <Button variant="accent" onClick={connect} loading={loading}>
+        Connect Stellar Wallet
+      </Button>
+
+      {error && <p className={styles.error}>{error}</p>}
+
+      {pairingUri && (
+        <div className={styles.pairing} role="dialog" aria-label="Connect wallet">
+          {isMobile ? (
+            <a
+              href={`lobstr://wc?uri=${encodeURIComponent(pairingUri)}`}
+              className={styles.deepLink}
+            >
+              Open in LOBSTR
+            </a>
+          ) : (
+            <div className={styles.qr}>
+              <p className={styles.qrLabel}>Scan with your Stellar wallet</p>
+              {QRCode ? (
+                <QRCode value={pairingUri} size={220} />
+              ) : (
+                <p className={styles.qrLabel}>Loading QR…</p>
+              )}
+              <p className={styles.qrHint}>Works with LOBSTR, xBull, and other WalletConnect wallets</p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useWalletConnect.ts
+++ b/src/hooks/useWalletConnect.ts
@@ -1,0 +1,100 @@
+"use client";
+
+/**
+ * useWalletConnect — WalletConnect session management for Stellar mobile wallets.
+ *
+ * Uses the Stellar WalletConnect URI scheme to generate a pairing URI,
+ * display a QR code on desktop, and a deep link on mobile (LOBSTR, xBull, etc.).
+ *
+ * Session is persisted in localStorage so it survives page refreshes.
+ * Disconnect clears the session.
+ *
+ * NOTE: Requires NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID in environment.
+ * Get a project ID at https://cloud.walletconnect.com
+ */
+
+import { useState, useEffect, useCallback } from "react";
+
+const SESSION_KEY = "ajosave_wc_session";
+
+export interface WalletSession {
+  publicKey: string;
+  walletName: string;
+  pairingUri: string;
+}
+
+export function useWalletConnect() {
+  const [session, setSession] = useState<WalletSession | null>(null);
+  const [pairingUri, setPairingUri] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Restore session from localStorage on mount
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(SESSION_KEY);
+      if (stored) setSession(JSON.parse(stored));
+    } catch {
+      // ignore parse errors
+    }
+  }, []);
+
+  const connect = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const projectId = process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID;
+      if (!projectId) throw new Error("NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID is not set");
+
+      // Dynamically import WalletConnect to avoid SSR issues
+      const { SignClient } = await import("@walletconnect/sign-client");
+
+      const client = await SignClient.init({
+        projectId,
+        metadata: {
+          name: "Ajosave",
+          description: "Trustless rotating savings circles on Stellar",
+          url: "https://www.ajosave.app",
+          icons: ["https://www.ajosave.app/icon.png"],
+        },
+      });
+
+      const { uri, approval } = await client.connect({
+        requiredNamespaces: {
+          stellar: {
+            methods: ["stellar_signAndSubmitXDR", "stellar_signXDR"],
+            chains: ["stellar:testnet"],
+            events: ["accountsChanged"],
+          },
+        },
+      });
+
+      if (!uri) throw new Error("Failed to generate pairing URI");
+      setPairingUri(uri);
+
+      // Wait for wallet approval
+      const sessionData = await approval();
+      const accounts = sessionData.namespaces.stellar?.accounts ?? [];
+      const publicKey = accounts[0]?.split(":")[2] ?? "";
+      const walletName = sessionData.peer.metadata.name;
+
+      const newSession: WalletSession = { publicKey, walletName, pairingUri: uri };
+      localStorage.setItem(SESSION_KEY, JSON.stringify(newSession));
+      setSession(newSession);
+      setPairingUri(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Connection failed");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const disconnect = useCallback(() => {
+    localStorage.removeItem(SESSION_KEY);
+    setSession(null);
+    setPairingUri(null);
+    setError(null);
+  }, []);
+
+  return { session, pairingUri, loading, error, connect, disconnect };
+}


### PR DESCRIPTION
## Summary

Closes #313

Mobile users can now connect LOBSTR and other WalletConnect-compatible Stellar wallets.

## Changes

- **`src/hooks/useWalletConnect.ts`** — hook that manages WalletConnect session via `@walletconnect/sign-client`; session persisted in `localStorage` across page refreshes; `disconnect()` clears session
- **`src/components/wallet/WalletConnectButton.tsx`** — desktop shows QR code (via `qrcode.react`, dynamically imported); mobile shows a deep link (`lobstr://wc?uri=...`); connected state shows wallet name + truncated public key + disconnect button
- **`src/components/wallet/WalletConnectButton.module.css`** — component styles

## Environment

Requires `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID` — get a free project ID at https://cloud.walletconnect.com

## Acceptance Criteria

- [x] WalletConnect QR code shown on desktop
- [x] Deep link on mobile (LOBSTR `lobstr://wc` scheme)
- [x] Session persists across page refreshes (localStorage)
- [x] Disconnect clears session