### PR TITLE
feat: structured logging with correlation IDs (#258)

### DIFF
--- a/src/lib/__tests__/paystack.test.ts
+++ b/src/lib/__tests__/paystack.test.ts
@@ -3,7 +3,11 @@
  */
 
 jest.mock("axios", () => ({
-  create: jest.fn(() => ({ post: jest.fn(), get: jest.fn() })),
+  create: jest.fn(() => ({
+    post: jest.fn(),
+    get: jest.fn(),
+    interceptors: { request: { use: jest.fn() } },
+  })),
 }));
 jest.mock("@/server/config", () => ({
   serverConfig: { paystack: { secretKey: "sk_test_secret" } },

--- a/src/lib/correlation.ts
+++ b/src/lib/correlation.ts
@@ -1,0 +1,11 @@
+import { AsyncLocalStorage } from "async_hooks";
+
+const store = new AsyncLocalStorage<{ correlationId: string }>();
+
+export function runWithCorrelationId<T>(correlationId: string, fn: () => T): T {
+  return store.run({ correlationId }, fn);
+}
+
+export function getCorrelationId(): string | undefined {
+  return store.getStore()?.correlationId;
+}

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,10 +1,33 @@
 import pino from "pino";
+import { getCorrelationId } from "./correlation";
 
-const logger = pino(
+const base = pino(
   { level: process.env.LOG_LEVEL ?? "info" },
   process.env.NODE_ENV !== "production"
     ? pino.transport({ target: "pino-pretty", options: { colorize: true } })
     : undefined
 );
+
+// Proxy that injects correlationId from AsyncLocalStorage on every log call
+const logger = new Proxy(base, {
+  get(target, prop) {
+    const val = (target as any)[prop];
+    if (typeof val !== "function") return val;
+    if (!["trace", "debug", "info", "warn", "error", "fatal"].includes(prop as string)) {
+      return val.bind(target);
+    }
+    return (...args: unknown[]) => {
+      const correlationId = getCorrelationId();
+      if (!correlationId) return (val as Function).apply(target, args);
+      // pino log methods: (obj, msg) or (msg)
+      if (args.length > 0 && typeof args[0] === "object" && args[0] !== null) {
+        args[0] = { correlationId, ...(args[0] as object) };
+      } else {
+        args = [{ correlationId }, ...args];
+      }
+      return (val as Function).apply(target, args);
+    };
+  },
+});
 
 export default logger;

--- a/src/lib/paystack.ts
+++ b/src/lib/paystack.ts
@@ -2,10 +2,18 @@ import axios from "axios";
 import { serverConfig } from "@/server/config";
 import type { SupportedCurrency } from "@/types";
 import { toSmallestUnit } from "./currency";
+import { getCorrelationId } from "./correlation";
 
 const client = axios.create({
   baseURL: "https://api.paystack.co",
   headers: { Authorization: `Bearer ${serverConfig.paystack.secretKey}` },
+});
+
+// Forward correlation ID on every outbound request
+client.interceptors.request.use((config) => {
+  const correlationId = getCorrelationId();
+  if (correlationId) config.headers["x-correlation-id"] = correlationId;
+  return config;
 });
 
 // Map our currency codes to Paystack currency codes

--- a/src/lib/sms.ts
+++ b/src/lib/sms.ts
@@ -1,7 +1,14 @@
 import axios from "axios";
 import { serverConfig } from "@/server/config";
+import { getCorrelationId } from "./correlation";
 
 const client = axios.create({ baseURL: "https://api.ng.termii.com/api" });
+
+client.interceptors.request.use((config) => {
+  const correlationId = getCorrelationId();
+  if (correlationId) config.headers["x-correlation-id"] = correlationId;
+  return config;
+});
 
 export async function sendOtp(phone: string): Promise<string> {
   const otp = Math.floor(100000 + Math.random() * 900000).toString();

--- a/src/server/middleware/__tests__/withErrorHandler.test.ts
+++ b/src/server/middleware/__tests__/withErrorHandler.test.ts
@@ -3,6 +3,11 @@ jest.mock("@/lib/logger", () => ({
   default: { child: jest.fn(() => ({ info: jest.fn(), error: jest.fn() })) },
 }));
 
+jest.mock("@/lib/correlation", () => ({
+  runWithCorrelationId: jest.fn((_id: string, fn: () => unknown) => fn()),
+  getCorrelationId: jest.fn(),
+}));
+
 jest.mock("next/server", () => ({
   NextRequest: class {},
   NextResponse: {
@@ -48,7 +53,7 @@ beforeEach(() => {
 });
 
 describe("withErrorHandler", () => {
-  it("returns the handler response and sets x-request-id header", async () => {
+  it("returns the handler response and sets x-correlation-id header", async () => {
     const okRes = makeOkResponse();
     const handler = jest.fn().mockResolvedValue(okRes);
 
@@ -56,21 +61,34 @@ describe("withErrorHandler", () => {
 
     expect(res).toBe(okRes);
     expect((okRes.headers.set as jest.Mock)).toHaveBeenCalledWith(
-      "x-request-id",
+      "x-correlation-id",
       expect.any(String)
     );
   });
 
-  it("propagates the incoming x-request-id to the response header", async () => {
+  it("propagates the incoming x-correlation-id to the response header", async () => {
     const okRes = makeOkResponse();
     const handler = jest.fn().mockResolvedValue(okRes);
 
     await withErrorHandler(handler)(
-      makeReq({ headers: { "x-request-id": "my-trace-id" } }),
+      makeReq({ headers: { "x-correlation-id": "my-trace-id" } }),
       undefined
     );
 
-    expect((okRes.headers.set as jest.Mock)).toHaveBeenCalledWith("x-request-id", "my-trace-id");
+    expect((okRes.headers.set as jest.Mock)).toHaveBeenCalledWith("x-correlation-id", "my-trace-id");
+  });
+
+  it("falls back to x-request-id when x-correlation-id is absent", async () => {
+    const okRes = makeOkResponse();
+    await withErrorHandler(jest.fn().mockResolvedValue(okRes))(
+      makeReq({ headers: { "x-request-id": "req-id-fallback" } }),
+      undefined
+    );
+
+    expect((okRes.headers.set as jest.Mock)).toHaveBeenCalledWith(
+      "x-correlation-id",
+      "req-id-fallback"
+    );
   });
 
   it("logs method, path, statusCode, durationMs on success", async () => {
@@ -112,7 +130,7 @@ describe("withErrorHandler", () => {
     );
   });
 
-  it("captures exception in Sentry with requestId on error", async () => {
+  it("captures exception in Sentry with correlationId on error", async () => {
     const error = new Error("sentry-test");
 
     await withErrorHandler(jest.fn().mockRejectedValue(error))(makeReq(), undefined);
@@ -120,38 +138,38 @@ describe("withErrorHandler", () => {
     expect(Sentry.captureException).toHaveBeenCalledWith(
       error,
       expect.objectContaining({
-        extra: expect.objectContaining({ requestId: expect.any(String) }),
+        extra: expect.objectContaining({ correlationId: expect.any(String) }),
       })
     );
   });
 
-  it("sets x-request-id on the error response", async () => {
+  it("sets x-correlation-id on the error response", async () => {
     const res = await withErrorHandler(jest.fn().mockRejectedValue(new Error("fail")))(
-      makeReq({ headers: { "x-request-id": "err-trace" } }),
+      makeReq({ headers: { "x-correlation-id": "err-trace" } }),
       undefined
     );
 
-    expect((res.headers.set as jest.Mock)).toHaveBeenCalledWith("x-request-id", "err-trace");
+    expect((res.headers.set as jest.Mock)).toHaveBeenCalledWith("x-correlation-id", "err-trace");
   });
 
-  it("generates a UUID requestId when none is provided", async () => {
+  it("generates a UUID correlationId when none is provided", async () => {
     const okRes = makeOkResponse();
     await withErrorHandler(jest.fn().mockResolvedValue(okRes))(makeReq(), undefined);
 
     const [[, id]] = (okRes.headers.set as jest.Mock).mock.calls.filter(
-      ([k]: [string]) => k === "x-request-id"
+      ([k]: [string]) => k === "x-correlation-id"
     );
     expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
   });
 
-  it("passes requestId to logger.child", async () => {
+  it("passes correlationId to logger.child", async () => {
     const okRes = makeOkResponse();
     await withErrorHandler(jest.fn().mockResolvedValue(okRes))(
-      makeReq({ headers: { "x-request-id": "trace-123" } }),
+      makeReq({ headers: { "x-correlation-id": "trace-123" } }),
       undefined
     );
 
-    expect(mockLogger.child).toHaveBeenCalledWith({ requestId: "trace-123" });
+    expect(mockLogger.child).toHaveBeenCalledWith({ correlationId: "trace-123" });
   });
 });
 

--- a/src/server/middleware/index.ts
+++ b/src/server/middleware/index.ts
@@ -6,6 +6,7 @@ import type { ApiError } from "@/types";
 import { getRedis } from "@/lib/redis";
 import { randomUUID } from "crypto";
 import logger from "@/lib/logger";
+import { runWithCorrelationId } from "@/lib/correlation";
 
 type Handler = (_req: NextRequest, _ctx?: unknown) => Promise<NextResponse>;
 
@@ -44,39 +45,43 @@ export function withAdminAuth(handler: Handler): Handler {
 
 export function withErrorHandler(handler: Handler): Handler {
   return async (req, ctx) => {
-    const requestId =
-      req.headers.get("x-request-id") ?? randomUUID();
+    const correlationId =
+      req.headers.get("x-correlation-id") ??
+      req.headers.get("x-request-id") ??
+      randomUUID();
     const { pathname } = new URL(req.url);
     const start = Date.now();
-    const reqLogger = logger.child({ requestId });
 
-    try {
-      const response = await handler(req, ctx);
-      reqLogger.info({
-        method: req.method,
-        path: pathname,
-        statusCode: response.status,
-        durationMs: Date.now() - start,
-      });
-      response.headers.set("x-request-id", requestId);
-      return response;
-    } catch (err) {
-      const durationMs = Date.now() - start;
-      Sentry.captureException(err, { extra: { url: req.url, method: req.method, requestId } });
-      reqLogger.error({
-        method: req.method,
-        path: pathname,
-        statusCode: 500,
-        durationMs,
-        err,
-      });
-      const res = NextResponse.json<ApiError>(
-        { success: false, error: "Internal server error", code: "INTERNAL_ERROR" },
-        { status: 500 }
-      );
-      res.headers.set("x-request-id", requestId);
-      return res;
-    }
+    return runWithCorrelationId(correlationId, async () => {
+      const reqLogger = logger.child({ correlationId });
+      try {
+        const response = await handler(req, ctx);
+        reqLogger.info({
+          method: req.method,
+          path: pathname,
+          statusCode: response.status,
+          durationMs: Date.now() - start,
+        });
+        response.headers.set("x-correlation-id", correlationId);
+        return response;
+      } catch (err) {
+        const durationMs = Date.now() - start;
+        Sentry.captureException(err, { extra: { url: req.url, method: req.method, correlationId } });
+        reqLogger.error({
+          method: req.method,
+          path: pathname,
+          statusCode: 500,
+          durationMs,
+          err,
+        });
+        const res = NextResponse.json<ApiError>(
+          { success: false, error: "Internal server error", code: "INTERNAL_ERROR" },
+          { status: 500 }
+        );
+        res.headers.set("x-correlation-id", correlationId);
+        return res;
+      }
+    });
   };
 }
 


### PR DESCRIPTION
## Summary

Resolves #258.

Implements structured JSON logging with per-request correlation IDs for full traceability across the request lifecycle and downstream service calls.

## Changes

- **`src/lib/correlation.ts`** (new) — `AsyncLocalStorage`-based store exposing `runWithCorrelationId` and `getCorrelationId`. Zero-overhead propagation without threading IDs through every function signature.

- **`src/lib/logger.ts`** — Logger is now a `Proxy` that automatically merges `correlationId` from the store into every log call. All existing `logger.info/warn/error` calls gain the field for free.

- **`src/server/middleware/index.ts`** — `withErrorHandler` wraps each request in `runWithCorrelationId`. Reads `x-correlation-id` from the incoming request (falls back to `x-request-id` for backwards compatibility), and echoes it on the response as `x-correlation-id`.

- **`src/lib/paystack.ts`** — Axios request interceptor forwards `x-correlation-id` on every outbound Paystack call.

- **`src/lib/sms.ts`** — Same interceptor pattern for Termii SMS calls.

## Acceptance criteria

| Criterion | Status |
|---|---|
| All logs output as JSON | ✅ pino already outputs JSON in production; `LOG_LEVEL` env var already supported |
| Each request gets a unique correlation ID | ✅ UUID generated in `withErrorHandler` if no header present |
| Correlation ID propagated to downstream calls | ✅ Paystack + SMS via axios interceptors; Stellar logger calls pick it up automatically via the proxy |
| Log level configurable via env var | ✅ `LOG_LEVEL` env var already wired into pino |

## Testing

- Updated `withErrorHandler.test.ts` — 9 tests covering correlation ID propagation, fallback, UUID generation, Sentry capture, and logging fields.
- Updated `paystack.test.ts` — mock updated to include `interceptors`; all 8 tests pass.