### PR TITLE
feat: add copy-to-clipboard invite link for circle creators (#252)

### DIFF
--- a/src/app/circles/[id]/page.module.css
+++ b/src/app/circles/[id]/page.module.css
@@ -42,3 +42,17 @@
 }
 .detailRow dt { color: var(--color-text-secondary); }
 .detailRow dd { color: var(--color-text-primary); font-weight: var(--font-medium); }
+
+.inviteLinkCell {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.inviteLinkText {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 180px;
+}

--- a/src/app/circles/[id]/page.tsx
+++ b/src/app/circles/[id]/page.tsx
@@ -11,6 +11,7 @@ import { getCurrencySymbol, SupportedCurrency } from "@/lib/currency";
 import { format } from "date-fns";
 import type { Metadata } from "next";
 import { CircleChat } from "@/components/circle/CircleChat";
+import { CopyButton } from "@/components/ui/CopyButton";
 import styles from "./page.module.css";
 
 interface Props {
@@ -109,6 +110,20 @@ export default async function CircleDetailPage({ params }: Props) {
                 <div className={styles.detailRow}>
                   <dt>Next Payout</dt>
                   <dd>{format(new Date(circle.nextPayoutAt), "MMM d, yyyy")}</dd>
+                </div>
+              )}
+              {isCreator && (
+                <div className={styles.detailRow}>
+                  <dt>Invite Link</dt>
+                  <dd className={styles.inviteLinkCell}>
+                    <span className={styles.inviteLinkText}>
+                      {`${process.env.NEXT_PUBLIC_APP_URL}/circles/${circle.id}/join`}
+                    </span>
+                    <CopyButton
+                      text={`${process.env.NEXT_PUBLIC_APP_URL}/circles/${circle.id}/join`}
+                      label="Copy invite link"
+                    />
+                  </dd>
                 </div>
               )}
             </dl>


### PR DESCRIPTION
## Summary

Resolves #252.

Adds a copy-to-clipboard invite link on the circle detail page, visible only to the circle creator.

## Changes

**`src/app/circles/[id]/page.tsx`**
- Import `CopyButton` component
- Add an **Invite Link** row inside the Circle Details card, rendered only when `isCreator === true`
- Invite URL: `${NEXT_PUBLIC_APP_URL}/circles/{id}/join` — routes directly to the existing join page

**`src/app/circles/[id]/page.module.css`**
- Add `.inviteLinkCell` (flex row with gap) and `.inviteLinkText` (truncated URL) styles

## Acceptance criteria

| Criterion | Status |
|---|---|
| Unique invite URL generated per circle | ✅ `/circles/{id}/join` is unique per circle |
| Copy button copies URL to clipboard | ✅ `CopyButton` uses `navigator.clipboard.writeText` |
| Visual confirmation on copy | ✅ `CopyButton` swaps to a checkmark icon for 2 s |
| Invite link routes to circle join page | ✅ `/circles/[id]/join` already exists |

No new API routes, no new dependencies — reuses the existing `CopyButton` component.