### PR TITLE
feat: add reentrancy guard to Soroban payout function (#264)

### DIFF
--- a/contracts/ajo/src/integration_tests.rs
+++ b/contracts/ajo/src/integration_tests.rs
@@ -284,7 +284,39 @@ mod integration {
         assert!(!completed);
     }
 
-    // ─── Upgrade tests ────────────────────────────────────────────────────────
+    // ─── Reentrancy guard tests (issue #264) ─────────────────────────────────
+
+    /// Lock is released after a successful payout so subsequent calls are not blocked.
+    #[test]
+    fn test_payout_lock_released_after_success() {
+        let f = setup_fixture(3);
+        for m in f.members.iter() { f.client.join(m); }
+
+        f.env.ledger().with_mut(|l| l.timestamp = f.interval + 1);
+        f.client.payout(); // lock acquired → released
+
+        for m in f.members.iter() { f.client.contribute(m); }
+        f.env.ledger().with_mut(|l| l.timestamp = f.interval * 2 + 2);
+        f.client.payout(); // must succeed — lock was released
+
+        let (cycle, _, _, _) = f.client.get_state();
+        assert_eq!(cycle, 3);
+    }
+
+    /// Double-call is rejected: setting the lock before payout triggers the guard.
+    #[test]
+    #[should_panic(expected = "payout already in progress")]
+    fn test_payout_reentrancy_guard() {
+        let f = setup_fixture(2);
+        for m in f.members.iter() { f.client.join(m); }
+        f.env.ledger().with_mut(|l| l.timestamp = f.interval + 1);
+
+        // Simulate a re-entrant call by forcing the lock to true before payout.
+        f.client.set_payout_lock(&true);
+        f.client.payout(); // must panic: "payout already in progress"
+    }
+
+        // ─── Upgrade tests ────────────────────────────────────────────────────────
 
     /// upgrade: admin can upgrade the contract WASM and event is emitted
     #[test]

--- a/contracts/ajo/src/lib.rs
+++ b/contracts/ajo/src/lib.rs
@@ -61,6 +61,8 @@ pub enum DataKey {
     // TTL Configuration
     TtlThreshold,
     TtlExtendTo,
+    // Reentrancy guard (issue #264)
+    PayoutLock,
 }
 
 // ─── Contract ─────────────────────────────────────────────────────────────────
@@ -334,8 +336,28 @@ impl AjoContract {
     }
 
     /// Trigger payout to the current cycle's recipient. Only callable by admin after next_payout_time.
+    ///
+    /// # Security – Reentrancy Guard (issue #264)
+    /// Although Soroban's execution model does not support traditional EVM-style reentrancy,
+    /// a `PayoutLock` flag is set at the start of this function and cleared at the end as an
+    /// explicit defence-in-depth measure. Any re-entrant or concurrent invocation (e.g. via
+    /// cross-contract calls or future protocol changes) will panic with "payout already in progress".
+    /// The contract also follows the checks-effects-interactions pattern: all state mutations
+    /// occur before the external token transfer.
     pub fn payout(env: Env) {
         Self::extend_instance_ttl(&env);
+
+        // ─── Reentrancy guard: acquire lock ───────────────────────────────────
+        let locked: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::PayoutLock)
+            .unwrap_or(false);
+        if locked {
+            panic!("payout already in progress");
+        }
+        env.storage().instance().set(&DataKey::PayoutLock, &true);
+
         let admin: Address = env.storage().instance().get(&DataKey::Admin).expect("not initialized");
         admin.require_auth();
 
@@ -416,6 +438,9 @@ impl AjoContract {
         // ─── Interaction: Transfer tokens ─────────────────────────────────────
         let token_client = token::Client::new(&env, &token);
         token_client.transfer(&env.current_contract_address(), &recipient, &pot);
+
+        // ─── Reentrancy guard: release lock ───────────────────────────────────
+        env.storage().instance().set(&DataKey::PayoutLock, &false);
 
         // ─── Events ───────────────────────────────────────────────────────────
         env.events().publish((Symbol::new(&env, "payout"),), (recipient.clone(), pot, current_cycle));
@@ -641,6 +666,13 @@ impl AjoContract {
         env.storage()
             .persistent()
             .extend_ttl(key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+    }
+
+    /// Test-only helper: force the payout lock to a given value.
+    /// Used to simulate a re-entrant call in the Soroban sandbox.
+    #[cfg(test)]
+    pub fn set_payout_lock(env: Env, locked: bool) {
+        env.storage().instance().set(&DataKey::PayoutLock, &locked);
     }
 }
 


### PR DESCRIPTION
## Summary

Resolves #264.

Adds an explicit reentrancy guard to the `payout` function as a defence-in-depth measure.

## Changes

**`contracts/ajo/src/lib.rs`**
- Added `PayoutLock` to the `DataKey` enum
- `payout()` now sets `PayoutLock = true` at entry; panics with `"payout already in progress"` if already locked
- Lock is released (`PayoutLock = false`) after the token transfer completes
- Checks-effects-interactions order is preserved (state mutations before external call)
- Added `#[cfg(test)] set_payout_lock` helper to allow direct guard testing in the sandbox
- Added audit comment explaining the security rationale

**`contracts/ajo/src/integration_tests.rs`**
- `test_payout_lock_released_after_success`: verifies the lock is released after each payout so subsequent valid calls are not blocked
- `test_payout_reentrancy_guard`: forces `PayoutLock = true` via the test helper, then calls `payout()` — confirms it panics with `"payout already in progress"`

## Acceptance criteria

| Criterion | Status |
|---|---|
| Lock flag set before external calls | ✅ Set before any state mutation |
| Lock released after completion | ✅ Released after token transfer |
| Test confirms double-call is rejected | ✅ `test_payout_reentrancy_guard` |
| Audit note added to contract comments | ✅ Doc comment on `payout()` |