### PR TITLE
feat: add contract-level contribution amount validation (#265)

### DIFF
--- a/contracts/ajo/src/integration_tests.rs
+++ b/contracts/ajo/src/integration_tests.rs
@@ -106,7 +106,7 @@ mod integration {
 
                 // All members contribute for next cycle
                 for m in members.iter() {
-                    client.contribute(m);
+                    client.contribute(m, &100_000_000);
                 }
             }
         }
@@ -188,6 +188,24 @@ mod integration {
         f.client.join(&extra);
     }
 
+    /// contribute: rejects under-contribution (amount < required)
+    #[test]
+    #[should_panic(expected = "contribution amount must equal required amount")]
+    fn test_contribute_under_amount() {
+        let f = setup_fixture(2);
+        for m in f.members.iter() { f.client.join(m); }
+        f.client.contribute(&f.members.get(0).unwrap(), &(f.contribution - 1));
+    }
+
+    /// contribute: rejects over-contribution (amount > required)
+    #[test]
+    #[should_panic(expected = "contribution amount must equal required amount")]
+    fn test_contribute_over_amount() {
+        let f = setup_fixture(2);
+        for m in f.members.iter() { f.client.join(m); }
+        f.client.contribute(&f.members.get(0).unwrap(), &(f.contribution + 1));
+    }
+
     /// contribute: rejects non-member
     #[test]
     #[should_panic(expected = "not a member")]
@@ -197,7 +215,7 @@ mod integration {
             f.client.join(m);
         }
         let outsider = Address::generate(&f.env);
-        f.client.contribute(&outsider);
+        f.client.contribute(&outsider, &100_000_000);
     }
 
     /// contribute: rejects double contribution in same cycle
@@ -209,7 +227,7 @@ mod integration {
             f.client.join(m);
         }
         let member = f.members.get(0).unwrap();
-        f.client.contribute(&member); // second contribution in cycle 1
+        f.client.contribute(&member, &100_000_000); // second contribution in cycle 1
     }
 
     /// contribute: rejects before circle starts
@@ -219,7 +237,7 @@ mod integration {
         let f = setup_fixture(3);
         // Only one member joins — circle not started
         f.client.join(&f.members.get(0).unwrap());
-        f.client.contribute(&f.members.get(0).unwrap());
+        f.client.contribute(&f.members.get(0).unwrap(), &100_000_000);
     }
 
     /// payout: rejects before payout time
@@ -248,7 +266,7 @@ mod integration {
 
         // Contribute for cycle 2
         for m in f.members.iter() {
-            f.client.contribute(m);
+            f.client.contribute(m, &100_000_000);
         }
 
         // Cycle 2 payout (completes circle)
@@ -402,7 +420,7 @@ mod integration {
                 assert_eq!(current, cycle_num + 1);
                 assert!(!done);
                 for m in members.iter() {
-                    client.contribute(m);
+                    client.contribute(m, &100_000_000);
                 }
             }
         }
@@ -436,7 +454,7 @@ mod integration {
             client.payout();
             if cycle_num < *max_members {
                 for m in members.iter() {
-                    client.contribute(m);
+                    client.contribute(m, &100_000_000);
                 }
             }
         }

--- a/contracts/ajo/src/lib.rs
+++ b/contracts/ajo/src/lib.rs
@@ -248,9 +248,23 @@ impl AjoContract {
     }
 
     /// Contribute for the current cycle.
-    pub fn contribute(env: Env, member: Address) {
+    ///
+    /// # Amount Validation (issue #265)
+    /// The caller must supply the exact `amount` they intend to transfer.
+    /// The contract rejects any value that does not equal `ContributionAmount`,
+    /// preventing both under-contributions and over-contributions.
+    pub fn contribute(env: Env, member: Address, amount: i128) {
         Self::extend_instance_ttl(&env);
         member.require_auth();
+
+        let required_amount: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ContributionAmount)
+            .expect("not initialized");
+        if amount != required_amount {
+            panic!("contribution amount must equal required amount");
+        }
 
         let current_cycle: u32 = env.storage().instance().get(&DataKey::CurrentCycle).expect("not initialized");
         if current_cycle == 0 {
@@ -720,7 +734,7 @@ mod tests {
         client.payout(&signers.get(0).unwrap(), &op_hash);
         assert_eq!(token.balance(&members.get(0).unwrap()), 1_100_000_000);
 
-        for m in members.iter() { client.contribute(m); }
+        for m in members.iter() { client.contribute(m, &100_000_000); }
         env.ledger().with_mut(|l| l.timestamp = 172802);
 
         let op_hash2 = make_op_hash(&env, "payout:2");
@@ -728,7 +742,7 @@ mod tests {
         client.approve_operation(&signers.get(1).unwrap(), &op_hash2);
         client.payout(&signers.get(0).unwrap(), &op_hash2);
 
-        for m in members.iter() { client.contribute(m); }
+        for m in members.iter() { client.contribute(m, &100_000_000); }
         env.ledger().with_mut(|l| l.timestamp = 259203);
 
         let op_hash3 = make_op_hash(&env, "payout:3");
@@ -773,7 +787,7 @@ mod tests {
         env.mock_all_auths();
         let (_, members, _, _, client) = setup(&env);
         for m in members.iter() { client.join(m); }
-        client.contribute(&members.get(0).unwrap());
+        client.contribute(&members.get(0).unwrap(), &100_000_000);
     }
 
     #[test]
@@ -795,8 +809,8 @@ mod tests {
         client.payout();
 
         // Only members[0] and members[1] contribute for cycle 2; members[2] defaults
-        client.contribute(&members.get(0).unwrap());
-        client.contribute(&members.get(1).unwrap());
+        client.contribute(&members.get(0).unwrap(), &100_000_000);
+        client.contribute(&members.get(1).unwrap(), &100_000_000);
 
         env.ledger().with_mut(|l| l.timestamp = 172802);
         client.payout();
@@ -879,7 +893,7 @@ mod tests {
         }
 
         // Only member 0 contributes for cycle 2
-        client.contribute(&members.get(0).unwrap());
+        client.contribute(&members.get(0).unwrap(), &100_000_000);
 
         let status3 = client.get_contribution_status(&2u32);
         let (_, m0_paid) = status3.get(0).unwrap();

--- a/src/components/circle/ContributeButton.tsx
+++ b/src/components/circle/ContributeButton.tsx
@@ -30,7 +30,11 @@ export function ContributeButton({ circleId, circleName, amountNgn, cycleFrequen
       toast("Redirecting to payment…", "info");
       window.location.href = json.data.authorizationUrl;
     } catch (err) {
-      toast(err instanceof Error ? err.message : "Failed to initiate payment", "error");
+      const msg = err instanceof Error ? err.message : "Failed to initiate payment";
+      const display = msg.includes("contribution amount must equal required amount")
+        ? `Contribution must be exactly ₦${amountNgn.toLocaleString("en-NG")} — please do not modify the amount.`
+        : msg;
+      toast(display, "error");
       setLoading(false);
       setShowModal(false);
     }


### PR DESCRIPTION
Resolves #265.

## Changes

**`contracts/ajo/src/lib.rs`**
- `contribute()` now takes `amount: i128` from the caller
- Panics with `"contribution amount must equal required amount"` if `amount != ContributionAmount`
- All existing test calls updated to pass `&100_000_000`

**`contracts/ajo/src/integration_tests.rs`**
- `test_contribute_under_amount`: passes `contribution - 1`, expects panic
- `test_contribute_over_amount`: passes `contribution + 1`, expects panic

**`src/components/circle/ContributeButton.tsx`**
- Maps the contract error string to a clear user-facing message: `"Contribution must be exactly ₦X — please do not modify the amount."`

## Acceptance criteria
- ✅ `contribute()` rejects amounts != required_amount
- ✅ Error message returned for wrong amount
- ✅ Unit tests cover under and over contribution
- ✅ Frontend shows clear error message