### PR TITLE
feat: add Paystack split payment for platform fee (#134)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,15 @@ PAYSTACK_SECRET_KEY=replace_with_paystack_secret_key
 # Format: Starts with 'pk_test_' (test) or 'pk_live_' (production)
 NEXT_PUBLIC_PAYSTACK_PUBLIC_KEY=replace_with_paystack_public_key
 
+# [OPTIONAL] Paystack subaccount code for platform fee split
+# Purpose: Routes the platform fee to the platform's Paystack subaccount
+# How to get: Paystack Dashboard → Subaccounts → Create Subaccount
+# Format: ACCT_xxxxxxxxxxxxxxx
+PAYSTACK_PLATFORM_SUBACCOUNT=
+
+# [OPTIONAL] Platform fee percentage charged on each contribution (default: 0.5)
+PLATFORM_FEE_PERCENT=0.5
+
 # ─── SMS & OTP (Termii) ────────────────────────────────────────────────────────
 # [REQUIRED] Termii API key for sending SMS
 # Purpose: Sends OTP for authentication and payout notifications

--- a/src/app/api/circles/[id]/contribute/route.ts
+++ b/src/app/api/circles/[id]/contribute/route.ts
@@ -63,7 +63,7 @@ export const POST = withErrorHandler(async (_req: NextRequest, ctx: unknown) => 
 
   const callbackUrl = `${serverConfig.app.url}/circles/${params.id}/contribute/callback?reference=${reference}`;
 
-  const { authorizationUrl } = await initializePayment({
+  const { authorizationUrl, platformFee } = await initializePayment({
     email: (session.user as { email?: string }).email ?? `${userId}@ajosave.app`,
     amount: circle.contributionFiat,
     currency: circle.contributionCurrency,
@@ -86,8 +86,8 @@ export const POST = withErrorHandler(async (_req: NextRequest, ctx: unknown) => 
     [randomUUID(), params.id, member.id, circle.currentCycle, circle.contributionUsdc, reference, authorizationUrl]
   );
 
-  return NextResponse.json<ApiResponse<{ authorizationUrl: string; reference: string }>>({
+  return NextResponse.json<ApiResponse<{ authorizationUrl: string; reference: string; platformFee: number }>>({
     success: true,
-    data: { authorizationUrl, reference },
+    data: { authorizationUrl, reference, platformFee },
   });
 });

--- a/src/components/circle/ContributeButton.tsx
+++ b/src/components/circle/ContributeButton.tsx
@@ -6,6 +6,7 @@ import { useToast } from "@/components/ui/Toast";
 
 export function ContributeButton({ circleId }: { circleId: string }) {
   const [loading, setLoading] = useState(false);
+  const [feeInfo, setFeeInfo] = useState<{ authorizationUrl: string; platformFee: number } | null>(null);
   const { toast } = useToast();
 
   const handleContribute = async () => {
@@ -14,6 +15,12 @@ export function ContributeButton({ circleId }: { circleId: string }) {
       const res = await fetch(`/api/circles/${circleId}/contribute`, { method: "POST" });
       const json = await res.json();
       if (!json.success) throw new Error(json.error);
+      // Show fee info before redirecting
+      if (json.data.platformFee > 0) {
+        setFeeInfo(json.data);
+        setLoading(false);
+        return;
+      }
       toast("Redirecting to payment…", "info");
       window.location.href = json.data.authorizationUrl;
     } catch (err) {
@@ -21,6 +28,27 @@ export function ContributeButton({ circleId }: { circleId: string }) {
       setLoading(false);
     }
   };
+
+  if (feeInfo) {
+    const feeNgn = (feeInfo.platformFee / 100).toFixed(2);
+    return (
+      <div role="region" aria-label="Payment fee disclosure" style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+        <p style={{ fontSize: "0.875rem", color: "var(--color-text-muted)" }}>
+          A platform fee of <strong>₦{feeNgn}</strong> (0.5%) will be added to your contribution.
+        </p>
+        <Button
+          variant="accent"
+          onClick={() => {
+            toast("Redirecting to payment…", "info");
+            window.location.href = feeInfo.authorizationUrl;
+          }}
+        >
+          Proceed to Payment
+        </Button>
+        <Button variant="ghost" onClick={() => setFeeInfo(null)}>Cancel</Button>
+      </div>
+    );
+  }
 
   return (
     <Button variant="accent" onClick={handleContribute} loading={loading}>

--- a/src/lib/paystack.ts
+++ b/src/lib/paystack.ts
@@ -16,6 +16,18 @@ const PAYSTACK_CURRENCY_MAP: Record<SupportedCurrency, string> = {
   EUR: "EUR", // Note: Paystack may not support EUR directly, may need alternative provider
 };
 
+/** Platform fee as a fraction (e.g. 0.005 = 0.5%). Configurable via PLATFORM_FEE_PERCENT. */
+export const PLATFORM_FEE_RATE =
+  parseFloat(process.env.PLATFORM_FEE_PERCENT ?? "0.5") / 100;
+
+/**
+ * Calculate the platform fee for a given amount.
+ * Returns the fee in the same unit as `amount`.
+ */
+export function calculatePlatformFee(amount: number): number {
+  return Math.round(amount * PLATFORM_FEE_RATE);
+}
+
 export async function initializePayment(params: {
   email: string;
   amount: number;
@@ -23,19 +35,40 @@ export async function initializePayment(params: {
   reference: string;
   callbackUrl: string;
   metadata?: Record<string, unknown>;
-}): Promise<{ authorizationUrl: string; reference: string }> {
+}): Promise<{ authorizationUrl: string; reference: string; platformFee: number }> {
   const amountInSmallestUnit = toSmallestUnit(params.amount, params.currency);
   const paystackCurrency = PAYSTACK_CURRENCY_MAP[params.currency];
+  const platformFee = calculatePlatformFee(amountInSmallestUnit);
 
-  const { data } = await client.post("/transaction/initialize", {
+  const body: Record<string, unknown> = {
     email: params.email,
     amount: amountInSmallestUnit,
     currency: paystackCurrency,
     reference: params.reference,
     callback_url: params.callbackUrl,
-    metadata: params.metadata,
-  });
-  return { authorizationUrl: data.data.authorization_url, reference: data.data.reference };
+    metadata: {
+      ...params.metadata,
+      platform_fee: platformFee,
+      platform_fee_rate: PLATFORM_FEE_RATE,
+    },
+  };
+
+  // Add split if platform subaccount is configured
+  const platformSubaccount = serverConfig.paystack.platformSubaccount;
+  if (platformSubaccount) {
+    body.split = {
+      type: "flat",
+      bearer_type: "subaccount",
+      subaccounts: [{ subaccount: platformSubaccount, share: platformFee }],
+    };
+  }
+
+  const { data } = await client.post("/transaction/initialize", body);
+  return {
+    authorizationUrl: data.data.authorization_url,
+    reference: data.data.reference,
+    platformFee,
+  };
 }
 
 export async function verifyPayment(

--- a/src/server/config/index.ts
+++ b/src/server/config/index.ts
@@ -18,7 +18,10 @@ export const serverConfig = {
     issuer: process.env.USDC_ISSUER ?? "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
     assetCode: process.env.USDC_ASSET_CODE ?? "USDC",
   },
-  paystack: { secretKey: process.env.PAYSTACK_SECRET_KEY ?? "" },
+  paystack: {
+    secretKey: process.env.PAYSTACK_SECRET_KEY ?? "",
+    platformSubaccount: process.env.PAYSTACK_PLATFORM_SUBACCOUNT ?? "",
+  },
   termii: {
     apiKey: process.env.TERMII_API_KEY ?? "",
     senderId: process.env.TERMII_SENDER_ID ?? "Ajosave",


### PR DESCRIPTION
Closes #134

## Changes
- `PLATFORM_FEE_RATE` configurable via `PLATFORM_FEE_PERCENT` env var (default 0.5%)
- `calculatePlatformFee()` helper in `paystack.ts`
- Split config sent to Paystack when `PAYSTACK_PLATFORM_SUBACCOUNT` is set
- Fee disclosed to user in `ContributeButton` before redirecting to payment
- Updated `.env.example` with `PAYSTACK_PLATFORM_SUBACCOUNT` and `PLATFORM_FEE_PERCENT`