### PR TITLE
feat: accessible empty state illustrations (issue #247)

### DIFF
--- a/src/app/circles/page.tsx
+++ b/src/app/circles/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { listOpenCircles } from "@/server/services/circle.service";
 import { CircleCard } from "@/components/circle/CircleCard";
 import { CircleFilters } from "@/components/circle/CircleFilters";
+import { EmptyState } from "@/components/ui/EmptyState";
 import Link from "next/link";
 import styles from "./page.module.css";
 
@@ -30,6 +31,8 @@ export default async function CirclesPage({ searchParams }: Props) {
     currency: searchParams.currency,
   });
 
+  const hasFilters = !!(searchParams.search || searchParams.frequency || searchParams.minAmount || searchParams.maxAmount || searchParams.status || searchParams.currency);
+
   return (
     <div className={styles.page}>
       <div className="container">
@@ -43,10 +46,22 @@ export default async function CirclesPage({ searchParams }: Props) {
         <CircleFilters />
 
         {circles.length === 0 ? (
-          <div className={styles.empty}>
-            <p>No circles found matching your criteria.</p>
-            <Link href="/circles" className="btn btn--secondary">Clear all filters</Link>
-          </div>
+          <EmptyState
+            illustration={hasFilters ? "search" : "circles"}
+            title={hasFilters ? "No circles match your filters" : "No open circles yet"}
+            description={
+              hasFilters
+                ? "Try adjusting your search or filters to find what you're looking for."
+                : "Be the first to start a savings circle and invite others to join."
+            }
+            ctas={
+              hasFilters
+                ? [{ label: "Clear all filters", href: "/circles", variant: "secondary" }]
+                : [
+                    { label: "Create a circle", href: "/circles/create", variant: "primary" },
+                  ]
+            }
+          />
         ) : (
           <div className={styles.grid}>
             {circles.map((circle) => (

--- a/src/components/dashboard/LiveDashboard.module.css
+++ b/src/components/dashboard/LiveDashboard.module.css
@@ -40,41 +40,6 @@
   }
 }
 
-.empty {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--space-4);
-  padding: var(--space-20) 0;
-  color: var(--color-text-secondary);
-  text-align: center;
-}
-
-.emptyIllustration {
-  margin-bottom: var(--space-2);
-}
-
-.emptyTitle {
-  font-size: var(--text-xl);
-  font-weight: var(--font-semibold);
-  color: var(--color-text-primary);
-}
-
-.emptyText {
-  font-size: var(--text-sm);
-  color: var(--color-text-secondary);
-  max-width: 360px;
-  line-height: var(--leading-relaxed);
-}
-
-.emptyCtas {
-  display: flex;
-  gap: var(--space-3);
-  flex-wrap: wrap;
-  justify-content: center;
-  margin-top: var(--space-2);
-}
-
 .newItemsBanner {
   background: linear-gradient(
     135deg,

--- a/src/components/dashboard/LiveDashboard.tsx
+++ b/src/components/dashboard/LiveDashboard.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from "react";
 import type { Circle } from "@/types";
 import { CircleCard } from "@/components/circle/CircleCard";
 import { ConnectionStatus } from "@/components/ui/ConnectionStatus";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { usePolling } from "@/hooks/usePolling";
 import Link from "next/link";
 import styles from "./LiveDashboard.module.css";
@@ -59,33 +60,15 @@ export function LiveDashboard({ initialCircles }: LiveDashboardProps) {
       )}
 
       {circles.length === 0 ? (
-        <div className={styles.empty}>
-          <div className={styles.emptyIllustration} aria-hidden="true">
-            <svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Empty savings circle">
-              <circle cx="48" cy="48" r="44" stroke="var(--color-border)" strokeWidth="2" strokeDasharray="6 4" />
-              <circle cx="48" cy="20" r="6" fill="var(--color-bg-elevated)" stroke="var(--color-brand-primary)" strokeWidth="2" />
-              <circle cx="72" cy="34" r="6" fill="var(--color-bg-elevated)" stroke="var(--color-border)" strokeWidth="2" />
-              <circle cx="72" cy="62" r="6" fill="var(--color-bg-elevated)" stroke="var(--color-border)" strokeWidth="2" />
-              <circle cx="48" cy="76" r="6" fill="var(--color-bg-elevated)" stroke="var(--color-border)" strokeWidth="2" />
-              <circle cx="24" cy="62" r="6" fill="var(--color-bg-elevated)" stroke="var(--color-border)" strokeWidth="2" />
-              <circle cx="24" cy="34" r="6" fill="var(--color-bg-elevated)" stroke="var(--color-border)" strokeWidth="2" />
-              <circle cx="48" cy="48" r="10" fill="var(--color-brand-primary)" opacity="0.15" />
-              <text x="48" y="53" textAnchor="middle" fontSize="14" fill="var(--color-brand-primary)">₦</text>
-            </svg>
-          </div>
-          <h2 className={styles.emptyTitle}>Start your savings journey</h2>
-          <p className={styles.emptyText}>
-            You haven&apos;t joined any circles yet. Create your own or browse open circles to get started.
-          </p>
-          <div className={styles.emptyCtas}>
-            <Link href="/circles/create" className="btn btn--primary">
-              Create your first circle
-            </Link>
-            <Link href="/circles" className="btn btn--secondary">
-              Browse circles
-            </Link>
-          </div>
-        </div>
+        <EmptyState
+          illustration="circles"
+          title="Start your savings journey"
+          description="You haven't joined any circles yet. Create your own or browse open circles to get started."
+          ctas={[
+            { label: "Create your first circle", href: "/circles/create", variant: "primary" },
+            { label: "Browse circles", href: "/circles", variant: "secondary" },
+          ]}
+        />
       ) : (
         <div className={styles.grid}>
           {circles.map((circle) => (

--- a/src/components/ui/EmptyState.module.css
+++ b/src/components/ui/EmptyState.module.css
@@ -1,0 +1,33 @@
+.empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-20) 0;
+  text-align: center;
+}
+
+.illustration {
+  margin-bottom: var(--space-2);
+}
+
+.title {
+  font-size: var(--text-xl);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+}
+
+.description {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  max-width: 360px;
+  line-height: var(--leading-relaxed);
+}
+
+.ctas {
+  display: flex;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: var(--space-2);
+}

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -23,7 +23,7 @@ export function EmptyState({
 }: EmptyStateProps) {
   return (
     <div className={styles.empty} role="status">
-      <div className={styles.illustration} aria-hidden="true">
+      <div className={styles.illustration}>
         {illustration === "circles" ? <CirclesIllustration /> : <SearchIllustration />}
       </div>
       <h2 className={styles.title}>{title}</h2>

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -1,0 +1,90 @@
+import Link from "next/link";
+import styles from "./EmptyState.module.css";
+
+interface Cta {
+  label: string;
+  href: string;
+  variant?: "primary" | "secondary";
+}
+
+interface EmptyStateProps {
+  title: string;
+  description: string;
+  ctas?: Cta[];
+  /** "circles" shows the rotating-circle SVG; "search" shows a magnifier */
+  illustration?: "circles" | "search";
+}
+
+export function EmptyState({
+  title,
+  description,
+  ctas = [],
+  illustration = "circles",
+}: EmptyStateProps) {
+  return (
+    <div className={styles.empty} role="status">
+      <div className={styles.illustration} aria-hidden="true">
+        {illustration === "circles" ? <CirclesIllustration /> : <SearchIllustration />}
+      </div>
+      <h2 className={styles.title}>{title}</h2>
+      <p className={styles.description}>{description}</p>
+      {ctas.length > 0 && (
+        <div className={styles.ctas}>
+          {ctas.map((cta) => (
+            <Link
+              key={cta.href}
+              href={cta.href}
+              className={`btn btn--${cta.variant ?? "primary"}`}
+            >
+              {cta.label}
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CirclesIllustration() {
+  return (
+    <svg
+      width="96"
+      height="96"
+      viewBox="0 0 96 96"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label="Empty savings circle illustration"
+    >
+      <circle cx="48" cy="48" r="44" stroke="var(--color-border)" strokeWidth="2" strokeDasharray="6 4" />
+      <circle cx="48" cy="20" r="6" fill="var(--color-bg-elevated)" stroke="var(--color-brand-primary)" strokeWidth="2" />
+      <circle cx="72" cy="34" r="6" fill="var(--color-bg-elevated)" stroke="var(--color-border)" strokeWidth="2" />
+      <circle cx="72" cy="62" r="6" fill="var(--color-bg-elevated)" stroke="var(--color-border)" strokeWidth="2" />
+      <circle cx="48" cy="76" r="6" fill="var(--color-bg-elevated)" stroke="var(--color-border)" strokeWidth="2" />
+      <circle cx="24" cy="62" r="6" fill="var(--color-bg-elevated)" stroke="var(--color-border)" strokeWidth="2" />
+      <circle cx="24" cy="34" r="6" fill="var(--color-bg-elevated)" stroke="var(--color-border)" strokeWidth="2" />
+      <circle cx="48" cy="48" r="10" fill="var(--color-brand-primary)" opacity="0.15" />
+      <text x="48" y="53" textAnchor="middle" fontSize="14" fill="var(--color-brand-primary)">₦</text>
+    </svg>
+  );
+}
+
+function SearchIllustration() {
+  return (
+    <svg
+      width="96"
+      height="96"
+      viewBox="0 0 96 96"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label="No results found illustration"
+    >
+      <circle cx="42" cy="42" r="28" stroke="var(--color-border)" strokeWidth="2.5" />
+      <circle cx="42" cy="42" r="18" fill="var(--color-brand-primary)" opacity="0.08" />
+      <line x1="62" y1="62" x2="80" y2="80" stroke="var(--color-border)" strokeWidth="2.5" strokeLinecap="round" />
+      <line x1="34" y1="42" x2="50" y2="42" stroke="var(--color-border)" strokeWidth="2" strokeLinecap="round" />
+      <line x1="42" y1="34" x2="42" y2="50" stroke="var(--color-border)" strokeWidth="2" strokeLinecap="round" />
+    </svg>
+  );
+}


### PR DESCRIPTION
Make EmptyState SVG illustrations accessible to assistive technologies. Removes aria-hidden so  and  on SVGs are exposed. UI CTAs already wired for create/browse circles.\n\nCloses #247.