### PR TITLE
fix(#239): make landing page responsive on mobile (320px–768px)

### DIFF
--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -20,3 +20,14 @@
 .stepNum { flex-shrink: 0; display: flex; align-items: center; justify-content: center; width: 36px; height: 36px; border-radius: var(--radius-full); background: var(--color-brand-primary); color: #fff; font-size: var(--text-sm); font-weight: var(--font-bold); }
 .stepTitle { font-size: var(--text-base); font-weight: var(--font-semibold); color: var(--color-text-primary); margin-bottom: var(--space-1); }
 .stepDesc { font-size: var(--text-sm); color: var(--color-text-secondary); line-height: var(--leading-relaxed); }
+
+@media (max-width: 768px) {
+  .hero { padding: var(--space-12) 0 var(--space-10); }
+  .subheadline { font-size: var(--text-base); }
+  .cta { flex-direction: column; }
+  .cta a { width: 100%; }
+  .grid { grid-template-columns: 1fr; }
+  .features { padding: var(--space-12) 0; }
+  .steps { padding: var(--space-12) 0; }
+  .sectionTitle { font-size: var(--text-xl); margin-bottom: var(--space-8); }
+}


### PR DESCRIPTION
Fix landing page mobile responsiveness (320px–768px)
  
  Closes #239 
  
  Changes
  
  - Collapse feature grid to single column on mobile — minmax(220px) was causing horizontal overflow on
  320px viewports
  - Stack CTA buttons vertically at full width below 768px
  - Reduce hero and section padding on small screens
  - Reduce section title font size on mobile
  
  Tested on
  
  - Chrome DevTools: Galaxy S8 (360px), iPhone SE (375px), iPhone 12 Pro (390px), Surface Duo (540px)
  
  Files changed
  
  - src/app/page.module.css

