### PR TITLE
feat: add Redis caching for circle list queries (#144)

### DIFF
--- a/src/server/services/__tests__/circle.service.test.ts
+++ b/src/server/services/__tests__/circle.service.test.ts
@@ -12,6 +12,7 @@ import * as db from "@/lib/db";
 import * as soroban from "@/lib/soroban";
 import * as fx from "@/lib/fx";
 import * as stellar from "@/lib/stellar";
+import * as redis from "@/lib/redis";
 
 jest.mock("@/lib/db", () => ({
   query: jest.fn(),
@@ -26,6 +27,21 @@ jest.mock("@/lib/stellar", () => ({
 jest.mock("@/server/services/notification.service", () => ({
   notifyCircleCancelled: jest.fn().mockResolvedValue(undefined),
 }));
+
+const mockRedisGet = jest.fn();
+const mockRedisSet = jest.fn();
+const mockRedisDel = jest.fn();
+const mockRedisKeys = jest.fn();
+const mockRedisClient = {
+  get: mockRedisGet,
+  set: mockRedisSet,
+  del: mockRedisDel,
+  keys: mockRedisKeys,
+};
+jest.mock("@/lib/redis", () => ({
+  getRedis: jest.fn(),
+}));
+const mockGetRedis = redis.getRedis as jest.MockedFunction<typeof redis.getRedis>;
 
 const mockQuery = db.query as jest.MockedFunction<typeof db.query>;
 const mockTransaction = db.transaction as jest.MockedFunction<typeof db.transaction>;
@@ -131,6 +147,12 @@ beforeEach(() => {
   mockSendUsdcPayment.mockResolvedValue("refund-tx-hash");
   mockValidateStellarRecipient.mockResolvedValue(undefined);
   mockTransaction.mockImplementation(async (cb) => cb(mockQuery));
+  // Default: Redis returns no cached value
+  mockRedisGet.mockResolvedValue(null);
+  mockRedisSet.mockResolvedValue("OK");
+  mockRedisKeys.mockResolvedValue([]);
+  mockRedisDel.mockResolvedValue(1);
+  mockGetRedis.mockResolvedValue(mockRedisClient as any);
 });
 
 describe("circle.service", () => {
@@ -393,6 +415,100 @@ describe("circle.service", () => {
         expect.stringContaining("SET status = 'refunded'"),
         expect.anything()
       );
+    });
+  });
+
+  describe("Redis caching", () => {
+    const PAGINATED_RESULT = { data: [MOCK_CIRCLE], total: 1, page: 1, limit: 20 };
+
+    describe("listOpenCircles", () => {
+      it("returns cached result on cache hit without querying DB", async () => {
+        mockRedisGet.mockResolvedValue(JSON.stringify(PAGINATED_RESULT));
+
+        const result = await listOpenCircles();
+
+        expect(result).toEqual(PAGINATED_RESULT);
+        expect(mockQuery).not.toHaveBeenCalled();
+      });
+
+      it("queries DB and populates cache on cache miss", async () => {
+        mockRedisGet.mockResolvedValue(null);
+        mockQuery
+          .mockResolvedValueOnce({ rows: [MOCK_CIRCLE], rowCount: 1 } as any)
+          .mockResolvedValueOnce({ rows: [{ count: "1" }], rowCount: 1 } as any);
+
+        const result = await listOpenCircles();
+
+        expect(result).toEqual(PAGINATED_RESULT);
+        expect(mockQuery).toHaveBeenCalledTimes(2);
+        expect(mockRedisSet).toHaveBeenCalledWith(
+          expect.stringContaining("circles:open:"),
+          JSON.stringify(PAGINATED_RESULT),
+          { EX: 30 }
+        );
+      });
+
+      it("falls through to DB when Redis get throws", async () => {
+        mockRedisGet.mockRejectedValue(new Error("Redis unavailable"));
+        mockQuery
+          .mockResolvedValueOnce({ rows: [MOCK_CIRCLE], rowCount: 1 } as any)
+          .mockResolvedValueOnce({ rows: [{ count: "1" }], rowCount: 1 } as any);
+
+        const result = await listOpenCircles();
+
+        expect(result).toEqual(PAGINATED_RESULT);
+        expect(mockQuery).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe("cache invalidation", () => {
+      it("invalidates cache after createCircle", async () => {
+        mockRedisKeys.mockResolvedValue(["circles:open:{}"] as any);
+        jest.spyOn(soroban, "deployAjoContract").mockResolvedValue("CONTRACT_ID");
+        mockQuery.mockResolvedValue({ rows: [MOCK_CIRCLE], rowCount: 1 } as any);
+
+        await createCircle(CREATOR_ID, {
+          name: "New Circle",
+          contributionAmount: 16000,
+          contributionCurrency: "NGN" as const,
+          maxMembers: 5,
+          cycleFrequency: "monthly" as const,
+          payoutMethod: "fixed" as const,
+        });
+
+        expect(mockRedisKeys).toHaveBeenCalledWith("circles:open:*");
+        expect(mockRedisDel).toHaveBeenCalledWith(["circles:open:{}"]);
+      });
+
+      it("invalidates cache after joinCircle", async () => {
+        mockRedisKeys.mockResolvedValue(["circles:open:{}"] as any);
+        mockQuery
+          .mockResolvedValueOnce({ rows: [MOCK_CIRCLE], rowCount: 1 } as any)
+          .mockResolvedValueOnce({ rows: [], rowCount: 0 } as any)
+          .mockResolvedValueOnce({ rows: [MOCK_MEMBER], rowCount: 1 } as any);
+
+        await joinCircle(CIRCLE_ID, USER_ID);
+
+        expect(mockRedisKeys).toHaveBeenCalledWith("circles:open:*");
+        expect(mockRedisDel).toHaveBeenCalled();
+      });
+
+      it("does not throw when Redis del fails during invalidation", async () => {
+        mockRedisKeys.mockResolvedValue(["circles:open:{}"] as any);
+        mockRedisDel.mockRejectedValue(new Error("Redis unavailable"));
+        mockQuery.mockResolvedValue({ rows: [MOCK_CIRCLE], rowCount: 1 } as any);
+
+        await expect(
+          createCircle(CREATOR_ID, {
+            name: "New Circle",
+            contributionAmount: 16000,
+            contributionCurrency: "NGN" as const,
+            maxMembers: 5,
+            cycleFrequency: "monthly" as const,
+            payoutMethod: "fixed" as const,
+          })
+        ).resolves.toBeDefined();
+      });
     });
   });
 });

--- a/src/server/services/circle.service.ts
+++ b/src/server/services/circle.service.ts
@@ -6,6 +6,48 @@ import { getFiatPerUsdc } from "@/lib/fx";
 import { deployAjoContract } from "@/lib/soroban";
 import { sendUsdcPayment } from "@/lib/stellar";
 import { notifyCircleCancelled, notifyCirclePaused, notifyCircleResumed } from "./notification.service";
+import { getRedis } from "@/lib/redis";
+import logger from "@/lib/logger";
+
+const CACHE_KEY = "circles:open";
+const CACHE_TTL = 30; // seconds
+
+async function getCached<T>(key: string): Promise<T | null> {
+  try {
+    const redis = await getRedis();
+    const raw = await redis.get(key);
+    if (raw) {
+      logger.info({ key }, "cache hit");
+      return JSON.parse(raw) as T;
+    }
+    logger.info({ key }, "cache miss");
+  } catch (err) {
+    logger.warn({ err, key }, "Redis get failed, falling through to DB");
+  }
+  return null;
+}
+
+async function setCached(key: string, value: unknown): Promise<void> {
+  try {
+    const redis = await getRedis();
+    await redis.set(key, JSON.stringify(value), { EX: CACHE_TTL });
+  } catch (err) {
+    logger.warn({ err, key }, "Redis set failed");
+  }
+}
+
+async function invalidateCache(pattern: string): Promise<void> {
+  try {
+    const redis = await getRedis();
+    const keys = await redis.keys(pattern);
+    if (keys.length > 0) {
+      await redis.del(keys);
+    }
+    logger.info({ pattern }, "cache invalidated");
+  } catch (err) {
+    logger.warn({ err, pattern }, "Redis del failed");
+  }
+}
 
 export const fiatToUsdc = async (amount: number, currency: string): Promise<string> => {
   const rate = await getFiatPerUsdc(currency);
@@ -64,6 +106,7 @@ export async function createCircle(
     [id, input.name, creatorId, contributionUsdc, input.contributionAmount, input.contributionCurrency,
      input.maxMembers, input.cycleFrequency, input.payoutMethod, contractId, input.gracePeriodHours ?? 24]
   );
+  await invalidateCache(`${CACHE_KEY}:*`);
   return rows[0];
 }
 
@@ -98,6 +141,10 @@ export async function listOpenCircles(
 ): Promise<PaginatedCircles> {
   const safePage = Math.max(1, page);
   const safeLimit = Math.min(100, Math.max(1, limit));
+
+  const cacheKey = `${CACHE_KEY}:${JSON.stringify({ page: safePage, limit: safeLimit, ...filters })}`;
+  const cached = await getCached<PaginatedCircles>(cacheKey);
+  if (cached) return cached;
   const offset = (safePage - 1) * safeLimit;
 
   const statusFilter: CircleStatus = filters.status ?? 'open';
@@ -150,7 +197,9 @@ export async function listOpenCircles(
     query<{ count: string }>(countQueryText, queryParams),
   ]);
 
-  return { data: rows, total: parseInt(countRows[0].count, 10), page: safePage, limit: safeLimit };
+  const result = { data: rows, total: parseInt(countRows[0].count, 10), page: safePage, limit: safeLimit };
+  await setCached(cacheKey, result);
+  return result;
 }
 
 export async function getCirclesByUser(userId: string): Promise<Circle[]> {
@@ -183,7 +232,7 @@ export async function joinCircle(
   userId: string,
   isInvited: boolean = false
 ): Promise<Member> {
-  return transaction(async (q) => {
+  const member = await transaction(async (q) => {
     const { rows: circleRows } = await q<Circle>(
       `SELECT ${CIRCLE_SELECT} FROM circles WHERE id = $1 FOR UPDATE`,
       [circleId]
@@ -229,6 +278,8 @@ export async function joinCircle(
 
     return newMember[0];
   });
+  await invalidateCache(`${CACHE_KEY}:*`);
+  return member;
 }
 
 export async function getMembersByCircle(circleId: string): Promise<Member[]> {
@@ -244,6 +295,7 @@ export async function updateCircleStatus(id: string, status: CircleStatus): Prom
     "UPDATE circles SET status=$1, updated_at=NOW() WHERE id=$2",
     [status, id]
   );
+  await invalidateCache(`${CACHE_KEY}:*`);
 }
 
 export async function shuffleAndPersistPositions(
@@ -481,6 +533,8 @@ export async function cancelCircle(
     return updated[0];
   });
 
+  await invalidateCache(`${CACHE_KEY}:*`);
+
   // ── Step 2: Fetch members with refund_pending contributions ────────────────
   const { rows: refundRows } = await query<{
     member_id: string;
@@ -578,7 +632,7 @@ export async function pauseCircle(
   circleId: string,
   creatorId: string
 ): Promise<Circle> {
-  return transaction(async (q) => {
+  const result = await transaction(async (q) => {
     const { rows } = await q<Circle>(
       `SELECT ${CIRCLE_SELECT} FROM circles WHERE id = $1 FOR UPDATE`,
       [circleId]
@@ -605,13 +659,15 @@ export async function pauseCircle(
 
     return updated[0];
   });
+  await invalidateCache(`${CACHE_KEY}:*`);
+  return result;
 }
 
 export async function resumeCircle(
   circleId: string,
   creatorId: string
 ): Promise<Circle> {
-  return transaction(async (q) => {
+  const result = await transaction(async (q) => {
     const { rows } = await q<Circle>(
       `SELECT ${CIRCLE_SELECT} FROM circles WHERE id = $1 FOR UPDATE`,
       [circleId]
@@ -648,6 +704,8 @@ export async function resumeCircle(
 
     return updated[0];
   });
+  await invalidateCache(`${CACHE_KEY}:*`);
+  return result;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #144

Adds Redis caching to the `listOpenCircles` query to reduce DB load on every page load.

## Changes

**`circle.service.ts`**
- `getCached` / `setCached` / `invalidateCache` helpers using `@/lib/redis`
- `listOpenCircles` checks cache first; populates on miss with **30s TTL**
- Cache key includes page, limit, and all filters for correctness
- Cache invalidated on: `createCircle`, `joinCircle`, `updateCircleStatus`, `cancelCircle`, `pauseCircle`, `resumeCircle`
- Redis failures log a warning and fall through gracefully — no broken requests

**`circle.service.test.ts`**
- Added `jest.mock("@/lib/redis")` with full mock client
- 6 new tests covering: cache hit (no DB call), cache miss (DB queried + cache set with `EX: 30`), Redis get failure fallthrough, invalidation after `createCircle`, invalidation after `joinCircle`, Redis del failure does not throw

## Acceptance Criteria

- [x] Open circles list cached in Redis with 30s TTL
- [x] Cache invalidated when a circle is created or status changes
- [x] Cache hit/miss logged