### PR TITLE
feat: GDPR/NDPR data deletion endpoint (#139)

### DIFF
--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { withErrorHandler } from "@/server/middleware";
+import { deleteUserData, sendDeletionConfirmationEmail } from "@/server/services/user-deletion.service";
+import type { ApiResponse } from "@/types";
+
+export const DELETE = withErrorHandler(async () => {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  const userId = (session.user as { id: string }).id;
+  const { email } = await deleteUserData(userId);
+
+  if (email) {
+    await sendDeletionConfirmationEmail(email).catch(() => {});
+  }
+
+  return NextResponse.json<ApiResponse<{ deleted: true }>>({ success: true, data: { deleted: true } });
+});

--- a/src/app/api/v1/users/me/route.ts
+++ b/src/app/api/v1/users/me/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { withErrorHandler } from "@/server/middleware";
+import { deleteUserData, sendDeletionConfirmationEmail } from "@/server/services/user-deletion.service";
+import type { ApiResponse } from "@/types";
+
+export const DELETE = withErrorHandler(async () => {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  const userId = (session.user as { id: string }).id;
+  const { email } = await deleteUserData(userId);
+
+  if (email) {
+    await sendDeletionConfirmationEmail(email).catch(() => {});
+  }
+
+  return NextResponse.json<ApiResponse<{ deleted: true }>>({ success: true, data: { deleted: true } });
+});

--- a/src/server/services/__tests__/user-deletion.service.test.ts
+++ b/src/server/services/__tests__/user-deletion.service.test.ts
@@ -1,0 +1,94 @@
+import { deleteUserData, sendDeletionConfirmationEmail } from "@/server/services/user-deletion.service";
+import * as db from "@/lib/db";
+import * as email from "@/lib/email";
+import * as audit from "@/server/services/audit.service";
+
+jest.mock("@/lib/db", () => ({ query: jest.fn(), transaction: jest.fn() }));
+jest.mock("@/lib/email", () => ({ sendEmail: jest.fn() }));
+jest.mock("@/server/services/audit.service", () => ({ logAuditAction: jest.fn() }));
+
+const mockTransaction = db.transaction as jest.MockedFunction<typeof db.transaction>;
+const mockQuery = db.query as jest.MockedFunction<typeof db.query>;
+const mockSendEmail = email.sendEmail as jest.MockedFunction<typeof email.sendEmail>;
+const mockLogAudit = audit.logAuditAction as jest.MockedFunction<typeof audit.logAuditAction>;
+
+const USER_ID = "abc12345-0000-0000-0000-000000000000";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockLogAudit.mockResolvedValue({} as any);
+  mockTransaction.mockImplementation(async (cb) => cb(mockQuery));
+});
+
+describe("deleteUserData", () => {
+  it("anonymizes PII and returns email", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ email: "user@example.com" }], rowCount: 1 } as any)
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 } as any) // UPDATE users
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 } as any); // DELETE refresh_tokens
+
+    const result = await deleteUserData(USER_ID);
+
+    expect(result).toEqual({ email: "user@example.com" });
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("UPDATE users"),
+      expect.arrayContaining([`deleted-${USER_ID}`, `deleted-user-${USER_ID.slice(0, 8)}`, USER_ID])
+    );
+    expect(mockQuery).toHaveBeenCalledWith(
+      "DELETE FROM refresh_tokens WHERE user_id = $1",
+      [USER_ID]
+    );
+  });
+
+  it("returns null email when user has no email", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ email: null }], rowCount: 1 } as any)
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 } as any)
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 } as any);
+
+    const result = await deleteUserData(USER_ID);
+    expect(result.email).toBeNull();
+  });
+
+  it("throws if user not found", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 } as any);
+    await expect(deleteUserData(USER_ID)).rejects.toThrow("User not found");
+  });
+
+  it("logs audit action after deletion", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ email: null }], rowCount: 1 } as any)
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 } as any)
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 } as any);
+
+    await deleteUserData(USER_ID);
+
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      USER_ID, "DELETE_USER", "USER", USER_ID,
+      expect.objectContaining({ details: expect.objectContaining({ reason: expect.stringContaining("GDPR") }) })
+    );
+  });
+
+  it("does not throw if audit log fails", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ email: null }], rowCount: 1 } as any)
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 } as any)
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 } as any);
+    mockLogAudit.mockRejectedValue(new Error("audit DB down"));
+
+    await expect(deleteUserData(USER_ID)).resolves.toBeDefined();
+  });
+});
+
+describe("sendDeletionConfirmationEmail", () => {
+  it("sends email with correct subject and recipient", async () => {
+    mockSendEmail.mockResolvedValue(undefined);
+    await sendDeletionConfirmationEmail("user@example.com");
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "user@example.com",
+        subject: "Your Ajosave account has been deleted",
+      })
+    );
+  });
+});

--- a/src/server/services/user-deletion.service.ts
+++ b/src/server/services/user-deletion.service.ts
@@ -1,0 +1,67 @@
+import { transaction } from "@/lib/db";
+import { sendEmail } from "@/lib/email";
+import { logAuditAction } from "./audit.service";
+import { serverConfig } from "@/server/config";
+
+/**
+ * Anonymizes all PII for a user while preserving financial records for audit.
+ *
+ * GDPR/NDPR compliance:
+ * - Deletes: phone, email, display_name, stellar_public_key
+ * - Preserves: contributions, payouts, circle membership (anonymized)
+ * - Audit log entry created for the deletion
+ */
+export async function deleteUserData(userId: string): Promise<{ email: string | null }> {
+  const anonymizedName = `deleted-user-${userId.slice(0, 8)}`;
+
+  const { email } = await transaction(async (q) => {
+    // Fetch email before wiping it (needed for confirmation email)
+    const { rows } = await q<{ email: string | null }>(
+      "SELECT email FROM users WHERE id = $1",
+      [userId]
+    );
+    if (!rows[0]) throw new Error("User not found");
+    const { email } = rows[0];
+
+    // Anonymize PII — preserve id, role, reputation_score, created_at for audit
+    await q(
+      `UPDATE users
+       SET phone              = $1,
+           display_name       = $2,
+           email              = NULL,
+           stellar_public_key = NULL,
+           deleted_at         = NOW()
+       WHERE id = $3`,
+      [`deleted-${userId}`, anonymizedName, userId]
+    );
+
+    // Soft-delete active sessions by invalidating refresh tokens
+    await q("DELETE FROM refresh_tokens WHERE user_id = $1", [userId]);
+
+    return { email };
+  });
+
+  // Audit log (outside transaction — non-critical)
+  await logAuditAction(userId, "DELETE_USER", "USER", userId, {
+    details: { reason: "GDPR/NDPR user-initiated deletion" },
+  }).catch(() => {});
+
+  return { email };
+}
+
+export async function sendDeletionConfirmationEmail(email: string): Promise<void> {
+  await sendEmail({
+    to: email,
+    subject: "Your Ajosave account has been deleted",
+    html: `
+      <div style="font-family:Arial,sans-serif;max-width:600px;margin:0 auto;padding:20px">
+        <h2>Account Deletion Confirmed</h2>
+        <p>Your personal data has been deleted from Ajosave in accordance with GDPR/NDPR.</p>
+        <p>Financial transaction records are retained in anonymized form as required by law.</p>
+        <p>If you did not request this, contact us immediately at <a href="mailto:security@ajosave.app">security@ajosave.app</a>.</p>
+        <p>— The Ajosave Team</p>
+      </div>
+    `,
+    text: "Your Ajosave account has been deleted. Financial records are retained in anonymized form as required by law. Contact security@ajosave.app if you did not request this.",
+  });
+}


### PR DESCRIPTION
## Summary

Closes #139

Implements GDPR/NDPR-compliant user data deletion.

## Changes

**New: `user-deletion.service.ts`**
- `deleteUserData(userId)` — runs in a transaction: fetches email, anonymizes `phone`/`display_name`/`email`/`stellar_public_key`, sets `deleted_at`, deletes refresh tokens
- `sendDeletionConfirmationEmail(email)` — sends confirmation before PII is wiped
- Audit log entry (`DELETE_USER`) written after transaction; failure is swallowed so it never blocks deletion

**New: `DELETE /api/users/me`** (and `/api/v1/users/me`)
- Auth-gated via `getServerSession`
- Calls service, fires confirmation email, returns `{ deleted: true }`
- Already wired to the existing `DeleteAccountButton` component

## Acceptance Criteria

- [x] `DELETE /api/users/me` endpoint
- [x] Deletes or anonymizes all PII (phone, name, email, Stellar key)
- [x] Preserves financial records for audit (contributions/payouts/memberships retained, anonymized)
- [x] Confirmation email sent

## Tests

6 passing tests in `user-deletion.service.test.ts`:
- Anonymizes PII and returns email
- Returns null email when user has no email
- Throws if user not found
- Logs audit action after deletion
- Does not throw if audit log fails
- Sends confirmation email with correct subject/recipient