### PR TITLE
feat: add circle completion celebration screen (#316)

### DIFF
--- a/src/app/circles/[id]/page.tsx
+++ b/src/app/circles/[id]/page.tsx
@@ -13,6 +13,7 @@ import { format } from "date-fns";
 import type { Metadata } from "next";
 import { CircleChat } from "@/components/circle/CircleChat";
 import { CircleWaitlist } from "@/components/circle/CircleWaitlist";
+import { CircleCompletionScreen } from "@/components/circle/CircleCompletionScreen";
 import styles from "./page.module.css";
 
 interface Props {
@@ -71,6 +72,16 @@ export default async function CircleDetailPage({ params }: Props) {
     const status = await getWaitlistStatus(circle.id, userId);
     isOnWaitlist = status.isOnWaitlist;
     waitlistPosition = status.position;
+  }
+
+  if (circle.status === "completed") {
+    return (
+      <div className={styles.page}>
+        <div className="container">
+          <CircleCompletionScreen circle={circle} members={members} />
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/src/components/circle/CircleCompletionScreen.module.css
+++ b/src/components/circle/CircleCompletionScreen.module.css
@@ -1,0 +1,76 @@
+.wrapper {
+  text-align: center;
+  padding: var(--space-12) var(--space-6);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-6);
+}
+
+.confetti {
+  font-size: 4rem;
+  line-height: 1;
+  animation: pop 0.4s ease-out;
+}
+
+@keyframes pop {
+  0%   { transform: scale(0.5); opacity: 0; }
+  80%  { transform: scale(1.15); }
+  100% { transform: scale(1); opacity: 1; }
+}
+
+.heading {
+  font-size: var(--text-3xl);
+  font-weight: var(--font-bold);
+  color: var(--color-brand-primary);
+}
+
+.sub {
+  font-size: var(--text-base);
+  color: var(--color-text-secondary);
+  max-width: 40ch;
+}
+
+.stats {
+  display: flex;
+  gap: var(--space-8);
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-1);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  padding: var(--space-6) var(--space-8);
+  min-width: 120px;
+}
+
+.statValue {
+  font-size: var(--text-2xl);
+  font-weight: var(--font-bold);
+  color: var(--color-text-primary);
+}
+
+.statLabel {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.duration {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}
+
+.actions {
+  display: flex;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  justify-content: center;
+}

--- a/src/components/circle/CircleCompletionScreen.tsx
+++ b/src/components/circle/CircleCompletionScreen.tsx
@@ -1,0 +1,77 @@
+import Link from "next/link";
+import type { Circle, Member } from "@/types";
+import { getCurrencySymbol, SupportedCurrency } from "@/lib/currency";
+import { format } from "date-fns";
+import styles from "./CircleCompletionScreen.module.css";
+
+interface CircleCompletionScreenProps {
+  circle: Circle;
+  members: Member[];
+}
+
+export function CircleCompletionScreen({ circle, members }: CircleCompletionScreenProps) {
+  const currencySymbol = getCurrencySymbol(circle.contributionCurrency as SupportedCurrency);
+  const totalSaved = circle.contributionFiat * circle.maxMembers * circle.currentCycle;
+  const duration = circle.createdAt
+    ? `${format(new Date(circle.createdAt), "MMM yyyy")} – ${format(new Date(circle.updatedAt), "MMM yyyy")}`
+    : null;
+
+  const shareText = encodeURIComponent(
+    `🎉 Our savings circle "${circle.name}" just completed on Ajosave! ${members.length} members saved ${currencySymbol}${totalSaved.toLocaleString()} together. Join the next one at ajosave.app`
+  );
+  const twitterUrl = `https://twitter.com/intent/tweet?text=${shareText}`;
+  const whatsappUrl = `https://wa.me/?text=${shareText}`;
+
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.confetti} aria-hidden="true">🎉</div>
+      <h1 className={styles.heading}>Circle Complete! 🏆</h1>
+      <p className={styles.sub}>
+        Every member has been paid out. Great job staying committed!
+      </p>
+
+      <div className={styles.stats}>
+        <div className={styles.stat}>
+          <span className={styles.statValue}>
+            {currencySymbol}{totalSaved.toLocaleString()}
+          </span>
+          <span className={styles.statLabel}>Total Saved</span>
+        </div>
+        <div className={styles.stat}>
+          <span className={styles.statValue}>{members.length}</span>
+          <span className={styles.statLabel}>Members</span>
+        </div>
+        {duration && (
+          <div className={styles.stat}>
+            <span className={styles.statValue}>{circle.currentCycle}</span>
+            <span className={styles.statLabel}>Cycles Completed</span>
+          </div>
+        )}
+      </div>
+
+      {duration && <p className={styles.duration}>{duration}</p>}
+
+      <div className={styles.actions}>
+        <a
+          href={twitterUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="btn btn--secondary btn--sm"
+        >
+          Share on X (Twitter)
+        </a>
+        <a
+          href={whatsappUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="btn btn--secondary btn--sm"
+        >
+          Share on WhatsApp
+        </a>
+        <Link href="/circles/create" className="btn btn--primary btn--sm">
+          Start a New Circle
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #316

---

feat: circle completion celebration screen (#316)
  
  Shows a dedicated celebration screen when a circle's status is completed, replacing the normal detail
  view.
  
  Changes:
  
  - CircleCompletionScreen component with animated header, summary stats (total saved, member count, cycles
  completed), and duration range
  - Share to X (Twitter) and WhatsApp buttons
  - "Start a New Circle" CTA
  - Early return in CircleDetailPage when circle.status === "completed"
  
  Acceptance criteria met:
  
  - ✅ Completion screen shown when status = completed
  - ✅ Shows total saved, duration, member count
  - ✅ Share to social media (X + WhatsApp)
  - ✅ Option to start a new circle

