### PR TITLE
feat: add Termii SMS delivery status tracking (#334)

### DIFF
--- a/migrations/1748900000000_add-sms-logs.ts
+++ b/migrations/1748900000000_add-sms-logs.ts
@@ -1,0 +1,25 @@
+import { MigrationBuilder } from "node-pg-migrate";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createTable("sms_logs", {
+    id: { type: "uuid", primaryKey: true, default: pgm.func("gen_random_uuid()") },
+    message_id: { type: "varchar(255)", unique: true },
+    phone: { type: "varchar(20)", notNull: true },
+    message: { type: "text", notNull: true },
+    status: {
+      type: "varchar(20)",
+      notNull: true,
+      default: "'pending'",
+      check: "status IN ('pending', 'delivered', 'failed', 'expired')",
+    },
+    retry_sent: { type: "boolean", notNull: true, default: false },
+    created_at: { type: "timestamp", notNull: true, default: pgm.func("NOW()") },
+    updated_at: { type: "timestamp", notNull: true, default: pgm.func("NOW()") },
+  });
+  pgm.createIndex("sms_logs", "status");
+  pgm.createIndex("sms_logs", "created_at");
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropTable("sms_logs");
+}

--- a/src/app/api/admin/analytics/route.ts
+++ b/src/app/api/admin/analytics/route.ts
@@ -1,18 +1,22 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getDailyAnalytics, adminGetPerCircleAnalytics } from "@/server/services/analytics.service";
+import { getDailyAnalytics, adminGetPerCircleAnalytics, getSmsDeliveryStats } from "@/server/services/analytics.service";
 import { withAdminAuth, withErrorHandler } from "@/server/middleware";
 import type { ApiResponse } from "@/types";
 
 export const GET = withErrorHandler(
   withAdminAuth(async (req: NextRequest) => {
-    const dailyAnalytics = await getDailyAnalytics();
-    const circleAnalytics = await adminGetPerCircleAnalytics();
+    const [dailyAnalytics, circleAnalytics, smsDelivery] = await Promise.all([
+      getDailyAnalytics(),
+      adminGetPerCircleAnalytics(),
+      getSmsDeliveryStats(),
+    ]);
 
-    return NextResponse.json<ApiResponse<{ dailyAnalytics: typeof dailyAnalytics; circleAnalytics: typeof circleAnalytics }>>({
+    return NextResponse.json<ApiResponse<{ dailyAnalytics: typeof dailyAnalytics; circleAnalytics: typeof circleAnalytics; smsDelivery: typeof smsDelivery }>>({
       success: true,
       data: {
         dailyAnalytics,
         circleAnalytics,
+        smsDelivery,
       },
     });
   })

--- a/src/app/api/webhooks/termii/route.ts
+++ b/src/app/api/webhooks/termii/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withErrorHandler } from "@/server/middleware";
+import { getDb } from "@/lib/db";
+import { sendEmail } from "@/lib/email";
+import logger from "@/lib/logger";
+
+// Termii delivery report statuses that indicate final failure
+const FAILED_STATUSES = new Set(["failed", "expired", "rejected", "undelivered"]);
+const DELIVERED_STATUS = "delivered";
+
+export const POST = withErrorHandler(async (req: NextRequest) => {
+  const body = await req.json();
+  const { message_id, status, phone_number } = body as {
+    message_id?: string;
+    status?: string;
+    phone_number?: string;
+  };
+
+  if (!message_id || !status) {
+    return NextResponse.json({ success: false, error: "Missing fields" }, { status: 400 });
+  }
+
+  const db = await getDb();
+  const normalizedStatus = status.toLowerCase();
+  const deliveryStatus = normalizedStatus === DELIVERED_STATUS
+    ? "delivered"
+    : FAILED_STATUSES.has(normalizedStatus)
+    ? "failed"
+    : null;
+
+  if (!deliveryStatus) {
+    // Intermediate status (e.g. "sent", "submitted") — acknowledge but don't update
+    return NextResponse.json({ success: true });
+  }
+
+  const { rows } = await db.query<{ id: string; phone: string; message: string; retry_sent: boolean }>(
+    `UPDATE sms_logs
+     SET status = $1, updated_at = NOW()
+     WHERE message_id = $2 AND status = 'pending'
+     RETURNING id, phone, message, retry_sent`,
+    [deliveryStatus, message_id]
+  );
+
+  if (rows.length === 0) {
+    return NextResponse.json({ success: true }); // already processed or unknown
+  }
+
+  const log = rows[0];
+
+  if (deliveryStatus === "failed" && !log.retry_sent) {
+    // Attempt to find user email for fallback notification
+    const phone = phone_number ?? log.phone;
+    const { rows: users } = await db.query<{ email: string | null }>(
+      `SELECT email FROM users WHERE phone = $1 LIMIT 1`,
+      [phone]
+    );
+    const email = users[0]?.email;
+
+    if (email) {
+      try {
+        await sendEmail({
+          to: email,
+          subject: "Ajosave: SMS delivery failed — important notification",
+          html: `<p>We were unable to deliver an SMS to your phone. Here is the message:</p><p>${log.message}</p>`,
+          text: `We were unable to deliver an SMS to your phone. Message: ${log.message}`,
+        });
+        await db.query(`UPDATE sms_logs SET retry_sent = true WHERE id = $1`, [log.id]);
+        logger.info({ messageId: message_id }, "SMS failed — email fallback sent");
+      } catch (err) {
+        logger.error({ err, messageId: message_id }, "Email fallback failed");
+      }
+    }
+  }
+
+  return NextResponse.json({ success: true });
+});

--- a/src/lib/sms.ts
+++ b/src/lib/sms.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { serverConfig } from "@/server/config";
 import { getCorrelationId } from "./correlation";
+import { getDb } from "./db";
 
 const client = axios.create({ baseURL: "https://api.ng.termii.com/api" });
 
@@ -10,21 +11,19 @@ client.interceptors.request.use((config) => {
   return config;
 });
 
-export async function sendOtp(phone: string): Promise<string> {
-  const otp = Math.floor(100000 + Math.random() * 900000).toString();
-  await client.post("/sms/send", {
-    to: phone,
-    from: serverConfig.termii.senderId,
-    sms: `Your Ajosave verification code is: ${otp}. Valid for 10 minutes.`,
-    type: "plain",
-    channel: "generic",
-    api_key: serverConfig.termii.apiKey,
-  });
-  return otp;
+async function logSms(phone: string, message: string, messageId: string | null): Promise<void> {
+  const db = await getDb();
+  await db.query(
+    `INSERT INTO sms_logs (phone, message, message_id, status)
+     VALUES ($1, $2, $3, 'pending')`,
+    [phone, message, messageId]
+  );
 }
 
-export async function sendSms(phone: string, message: string): Promise<void> {
-  await client.post("/sms/send", {
+export async function sendOtp(phone: string): Promise<string> {
+  const otp = Math.floor(100000 + Math.random() * 900000).toString();
+  const message = `Your Ajosave verification code is: ${otp}. Valid for 10 minutes.`;
+  const res = await client.post("/sms/send", {
     to: phone,
     from: serverConfig.termii.senderId,
     sms: message,
@@ -32,6 +31,20 @@ export async function sendSms(phone: string, message: string): Promise<void> {
     channel: "generic",
     api_key: serverConfig.termii.apiKey,
   });
+  await logSms(phone, message, res.data?.message_id ?? null);
+  return otp;
+}
+
+export async function sendSms(phone: string, message: string): Promise<void> {
+  const res = await client.post("/sms/send", {
+    to: phone,
+    from: serverConfig.termii.senderId,
+    sms: message,
+    type: "plain",
+    channel: "generic",
+    api_key: serverConfig.termii.apiKey,
+  });
+  await logSms(phone, message, res.data?.message_id ?? null);
 }
 
 export async function sendPayoutReminderSms(

--- a/src/server/services/analytics.service.ts
+++ b/src/server/services/analytics.service.ts
@@ -214,6 +214,36 @@ export async function getDailyAnalytics(): Promise<DailyAnalyticsRow[]> {
   return rows;
 }
 
+export interface SmsDeliveryStats {
+  total: number;
+  delivered: number;
+  failed: number;
+  pending: number;
+  delivery_rate: number;
+}
+
+/**
+ * Fetch SMS delivery rate stats for the admin dashboard.
+ */
+export async function getSmsDeliveryStats(): Promise<SmsDeliveryStats> {
+  const { rows } = await query<{ status: string; count: string }>(
+    `SELECT status, COUNT(*)::text as count FROM sms_logs GROUP BY status`
+  );
+  const counts: Record<string, number> = {};
+  for (const row of rows) counts[row.status] = parseInt(row.count, 10);
+  const delivered = counts["delivered"] ?? 0;
+  const failed = counts["failed"] ?? 0;
+  const pending = counts["pending"] ?? 0;
+  const total = delivered + failed + pending;
+  return {
+    total,
+    delivered,
+    failed,
+    pending,
+    delivery_rate: total > 0 ? Math.round((delivered / total) * 10000) / 100 : 0,
+  };
+}
+
 /**
  * Fetch per-circle analytics for admins.
  */


### PR DESCRIPTION
Title: feat: add Termii SMS delivery status tracking (#334 )
  
  Description:
  
  Implements end-to-end SMS delivery tracking for Termii messages.
  
  Changes:
  
  - migrations/1748900000000_add-sms-logs.ts — new sms_logs table to persist every outbound SMS with its
  message_id, phone, status, and retry_sent flag
  - src/lib/sms.ts — captures message_id from Termii send response and writes a log row on every send
  - src/app/api/webhooks/termii/route.ts — POST /api/webhooks/termii delivery receipt handler; updates
  message status and sends an email fallback when delivery fails and the user has an email on file
  - src/server/services/analytics.service.ts — adds getSmsDeliveryStats() returning
  total/delivered/failed/pending counts and delivery rate %
  - src/app/api/admin/analytics/route.ts — exposes smsDelivery stats in the existing admin analytics
  endpoint
  
  Setup required: Configure the Termii dashboard delivery webhook URL to
  https://your-domain.com/api/webhooks/termii.
  
  Closes #334

