### PR TITLE
feat: add PWA support (#317)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -28,6 +28,7 @@ const securityHeaders = [
   { key: "X-Content-Type-Options", value: "nosniff" },
   { key: "X-Frame-Options", value: "DENY" },
   { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  { key: "Strict-Transport-Security", value: "max-age=63072000; includeSubDomains; preload" },
 ];
 
 const nextConfig = {
@@ -35,19 +36,6 @@ const nextConfig = {
   experimental: {
     serverComponentsExternalPackages: ["@stellar/stellar-sdk"],
     instrumentationHook: true,
-  },
-  async headers() {
-    return [
-      {
-        source: "/(.*)",
-        headers: [
-          {
-            key: "Strict-Transport-Security",
-            value: "max-age=63072000; includeSubDomains; preload",
-          },
-        ],
-      },
-    ];
   },
   async redirects() {
     return process.env.NODE_ENV === "production"
@@ -66,6 +54,11 @@ const nextConfig = {
       {
         source: "/(.*)",
         headers: securityHeaders,
+      },
+      {
+        // Service worker must not be cached so updates are picked up immediately
+        source: "/sw.js",
+        headers: [{ key: "Cache-Control", value: "no-cache, no-store, must-revalidate" }],
       },
     ];
   },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,6 +16,7 @@ export const metadata: Metadata = {
   description: "Join or create trustless savings circles (Ajo/Esusu) powered by Stellar Soroban smart contracts and USDC.",
   keywords: ["ajo", "esusu", "savings", "stellar", "soroban", "usdc", "nigeria", "defi"],
   metadataBase: new URL("https://www.ajosave.app"),
+  themeColor: "#0f7a4a",
   openGraph: {
     title: "Ajosave — On-Chain Rotating Savings",
     description: "Trustless Ajo/Esusu savings circles on Stellar. Contribute in Naira, receive in USDC.",


### PR DESCRIPTION
## Summary

Resolves #317 — Add Progressive Web App (PWA) support.

All four acceptance criteria are satisfied:

| Criterion | File |
|-----------|------|
| ✅ manifest with icons & theme color | `src/app/manifest.ts` |
| ✅ Service worker caches static assets | `public/sw.js` |
| ✅ Install prompt on mobile | `src/components/PWAProvider.tsx` |
| ✅ Offline page when network unavailable | `src/app/offline/page.tsx` |

## Changes in this PR

- **`src/app/layout.tsx`** — Added `themeColor: "#0f7a4a"` to metadata so browsers tint the address bar/status bar to match the app brand colour.
- **`next.config.mjs`** — Fixed a bug where two `async headers()` functions were defined; JavaScript only keeps the last one, so the HSTS header was silently dropped. Merged HSTS into the single `securityHeaders` array. Also added `Cache-Control: no-cache` for `/sw.js` so service worker updates are picked up immediately instead of being served stale.

## Testing

- Lighthouse PWA audit passes (installable, offline-ready, themed).
- Install banner appears on first visit on Android Chrome / iOS Safari Add-to-Home-Screen flow.
- Navigating to `/offline` while offline shows the fallback page.