### PR TITLE
feat: add Paystack recurring payment plans (#310)

### DIFF
--- a/migrations/1748700000000_add-paystack-recurring.ts
+++ b/migrations/1748700000000_add-paystack-recurring.ts
@@ -1,0 +1,11 @@
+import { query } from "@/lib/db";
+
+export async function up(): Promise<void> {
+  await query(`ALTER TABLE circles ADD COLUMN IF NOT EXISTS paystack_plan_code TEXT`);
+  await query(`ALTER TABLE members ADD COLUMN IF NOT EXISTS paystack_subscription_code TEXT`);
+}
+
+export async function down(): Promise<void> {
+  await query(`ALTER TABLE circles DROP COLUMN IF EXISTS paystack_plan_code`);
+  await query(`ALTER TABLE members DROP COLUMN IF EXISTS paystack_subscription_code`);
+}

--- a/src/app/api/circles/[id]/join/route.ts
+++ b/src/app/api/circles/[id]/join/route.ts
@@ -75,6 +75,6 @@ export const POST = withErrorHandler(async (req: NextRequest, ctx: unknown) => {
   }
 
   const userId = (session.user as { id: string }).id;
-  const member = await joinCircle(params.id, userId, isInvited);
+  const member = await joinCircle(params.id, userId, isInvited, parsed.data.authorizationCode);
   return NextResponse.json<ApiResponse<Member>>({ success: true, data: member }, { status: 201 });
 });

--- a/src/app/api/v1/circles/[id]/join/route.ts
+++ b/src/app/api/v1/circles/[id]/join/route.ts
@@ -75,6 +75,6 @@ export const POST = withErrorHandler(async (req: NextRequest, ctx: unknown) => {
   }
 
   const userId = (session.user as { id: string }).id;
-  const member = await joinCircle(params.id, userId, isInvited);
+  const member = await joinCircle(params.id, userId, isInvited, parsed.data.authorizationCode);
   return NextResponse.json<ApiResponse<Member>>({ success: true, data: member }, { status: 201 });
 });

--- a/src/app/api/v1/webhooks/paystack/route.ts
+++ b/src/app/api/v1/webhooks/paystack/route.ts
@@ -3,6 +3,7 @@ import { createHmac, timingSafeEqual } from "crypto";
 import { query, transaction } from "@/lib/db";
 import { serverConfig } from "@/server/config";
 import logger from "@/lib/logger";
+import { notifySubscriptionChargeFailed } from "@/server/services/notification.service";
 
 function verifySignature(payload: string, signature: string): boolean {
   if (!signature || !serverConfig.paystack.secretKey) return false;
@@ -50,6 +51,34 @@ export async function POST(req: NextRequest) {
   }
 
   logger.info({ eventId, event: event.event }, "Paystack webhook verified");
+
+  // ── subscription.charge_failed ────────────────────────────────────────────
+  if (event.event === "subscription.charge_failed") {
+    await query(
+      "INSERT INTO processed_webhooks (id, provider, event_type, payload) VALUES ($1, 'paystack', $2, $3)",
+      [eventId, event.event, event]
+    );
+
+    const subscriptionCode: string = event.data?.subscription_code;
+    if (subscriptionCode) {
+      const { rows } = await query<{ user_id: string; circle_name: string; contribution_fiat: number; contribution_currency: string }>(
+        `SELECT m.user_id, c.name AS circle_name, c.contribution_fiat, c.contribution_currency
+         FROM members m
+         JOIN circles c ON c.id = m.circle_id
+         WHERE m.paystack_subscription_code = $1`,
+        [subscriptionCode]
+      );
+      if (rows[0]) {
+        const { user_id, circle_name, contribution_fiat, contribution_currency } = rows[0];
+        const amount = `${contribution_fiat} ${contribution_currency}`;
+        notifySubscriptionChargeFailed(user_id, circle_name, amount).catch((err) =>
+          logger.error({ err }, "Failed to send charge-failed SMS")
+        );
+      }
+    }
+
+    return NextResponse.json({ received: true });
+  }
 
   if (event.event !== "charge.success") {
     // Record non-charge.success events too to prevent replays

--- a/src/app/api/webhooks/paystack/route.ts
+++ b/src/app/api/webhooks/paystack/route.ts
@@ -3,6 +3,7 @@ import { createHmac, timingSafeEqual } from "crypto";
 import { query, transaction } from "@/lib/db";
 import { serverConfig } from "@/server/config";
 import logger from "@/lib/logger";
+import { notifySubscriptionChargeFailed } from "@/server/services/notification.service";
 
 function verifySignature(payload: string, signature: string): boolean {
   if (!signature || !serverConfig.paystack.secretKey) return false;
@@ -50,6 +51,31 @@ export async function POST(req: NextRequest) {
   }
 
   logger.info({ eventId, event: event.event }, "Paystack webhook verified");
+
+  // ── subscription.charge_failed ────────────────────────────────────────────
+  if (event.event === "subscription.charge_failed") {
+    await query(
+      "INSERT INTO processed_webhooks (id, provider, event_type, payload) VALUES ($1, 'paystack', $2, $3)",
+      [eventId, event.event, event]
+    );
+    const subscriptionCode: string = event.data?.subscription_code;
+    if (subscriptionCode) {
+      const { rows } = await query<{ user_id: string; circle_name: string; contribution_fiat: number; contribution_currency: string }>(
+        `SELECT m.user_id, c.name AS circle_name, c.contribution_fiat, c.contribution_currency
+         FROM members m
+         JOIN circles c ON c.id = m.circle_id
+         WHERE m.paystack_subscription_code = $1`,
+        [subscriptionCode]
+      );
+      if (rows[0]) {
+        const { user_id, circle_name, contribution_fiat, contribution_currency } = rows[0];
+        notifySubscriptionChargeFailed(user_id, circle_name, `${contribution_fiat} ${contribution_currency}`).catch((err) =>
+          logger.error({ err }, "Failed to send charge-failed SMS")
+        );
+      }
+    }
+    return NextResponse.json({ received: true });
+  }
 
   if (event.event !== "charge.success") {
     // Record non-charge.success events too to prevent replays

--- a/src/lib/paystack.ts
+++ b/src/lib/paystack.ts
@@ -93,3 +93,52 @@ export async function verifyPayment(
     currency: data.data.currency,
   };
 }
+
+const FREQUENCY_INTERVAL: Record<string, string> = {
+  weekly: "weekly",
+  biweekly: "biweekly",
+  monthly: "monthly",
+};
+
+/** Create a Paystack recurring plan for a circle. Returns the plan code. */
+export async function createPlan(params: {
+  name: string;
+  amount: number;
+  currency: string;
+  frequency: string;
+}): Promise<string> {
+  const interval = FREQUENCY_INTERVAL[params.frequency] ?? "monthly";
+  const amountInSmallestUnit = toSmallestUnit(params.amount, params.currency as import("@/types").SupportedCurrency);
+  const { data } = await client.post("/plan", {
+    name: params.name,
+    amount: amountInSmallestUnit,
+    interval,
+    currency: PAYSTACK_CURRENCY_MAP[params.currency as import("@/types").SupportedCurrency] ?? params.currency,
+  });
+  return data.data.plan_code as string;
+}
+
+/** Subscribe a customer (by email) to a Paystack plan. Returns the subscription code. */
+export async function subscribeToPlan(params: {
+  email: string;
+  planCode: string;
+  authorizationCode: string;
+}): Promise<string> {
+  const { data } = await client.post("/subscription", {
+    customer: params.email,
+    plan: params.planCode,
+    authorization: params.authorizationCode,
+  });
+  return data.data.subscription_code as string;
+}
+
+/** Cancel a Paystack subscription. */
+export async function cancelSubscription(params: {
+  subscriptionCode: string;
+  emailToken: string;
+}): Promise<void> {
+  await client.post("/subscription/disable", {
+    code: params.subscriptionCode,
+    token: params.emailToken,
+  });
+}

--- a/src/lib/sms.ts
+++ b/src/lib/sms.ts
@@ -131,3 +131,12 @@ export async function sendCircleResumedSms(
   const message = `Ajosave: The circle "${circleName}" has been resumed. Normal schedule and payouts have been restored.`;
   await sendSms(phone, message);
 }
+
+export async function sendSubscriptionChargeFailedSms(
+  phone: string,
+  circleName: string,
+  amount: string
+): Promise<void> {
+  const message = `Ajosave: Your automatic contribution of ${amount} to "${circleName}" failed. Please update your payment method to avoid being marked as defaulted.`;
+  await sendSms(phone, message);
+}

--- a/src/server/services/circle.service.ts
+++ b/src/server/services/circle.service.ts
@@ -6,6 +6,7 @@ import { getFiatPerUsdc } from "@/lib/fx";
 import { deployAjoContract } from "@/lib/soroban";
 import { sendUsdcPayment } from "@/lib/stellar";
 import { notifyCircleCancelled, notifyCirclePaused, notifyCircleResumed } from "./notification.service";
+import { createPlan } from "@/lib/paystack";
 
 export const fiatToUsdc = async (amount: number, currency: string): Promise<string> => {
   const rate = await getFiatPerUsdc(currency);
@@ -55,14 +56,29 @@ export async function createCircle(
     console.error("[createCircle] Contract deployment failed, proceeding without contractId:", err);
   }
 
+  // Create a Paystack recurring plan for automated contributions
+  let paystackPlanCode: string | null = null;
+  try {
+    paystackPlanCode = await createPlan({
+      name: `Ajosave: ${input.name}`,
+      amount: input.contributionAmount,
+      currency: input.contributionCurrency,
+      frequency: input.cycleFrequency,
+    });
+  } catch (err) {
+    console.error("[createCircle] Paystack plan creation failed, proceeding without plan:", err);
+  }
+
   const { rows } = await query<Circle>(
     `INSERT INTO circles
        (id, name, creator_id, contribution_usdc, contribution_fiat, contribution_currency,
-        max_members, cycle_frequency, payout_method, contract_id, grace_period_hours, status, current_cycle, created_at, updated_at)
-     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,'open',0,NOW(),NOW())
+        max_members, cycle_frequency, payout_method, contract_id, grace_period_hours,
+        paystack_plan_code, status, current_cycle, created_at, updated_at)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,'open',0,NOW(),NOW())
      RETURNING ${CIRCLE_SELECT}`,
     [id, input.name, creatorId, contributionUsdc, input.contributionAmount, input.contributionCurrency,
-     input.maxMembers, input.cycleFrequency, input.payoutMethod, contractId, input.gracePeriodHours ?? 24]
+     input.maxMembers, input.cycleFrequency, input.payoutMethod, contractId, input.gracePeriodHours ?? 24,
+     paystackPlanCode]
   );
   return rows[0];
 }
@@ -181,11 +197,12 @@ export async function getCirclesByUser(userId: string): Promise<Circle[]> {
 export async function joinCircle(
   circleId: string,
   userId: string,
-  isInvited: boolean = false
+  isInvited: boolean = false,
+  paystackAuthCode?: string
 ): Promise<Member> {
   return transaction(async (q) => {
-    const { rows: circleRows } = await q<Circle>(
-      `SELECT ${CIRCLE_SELECT} FROM circles WHERE id = $1 FOR UPDATE`,
+    const { rows: circleRows } = await q<Circle & { paystackPlanCode?: string }>(
+      `SELECT ${CIRCLE_SELECT}, paystack_plan_code as "paystackPlanCode" FROM circles WHERE id = $1 FOR UPDATE`,
       [circleId]
     );
     const circle = circleRows[0];
@@ -214,6 +231,31 @@ export async function joinCircle(
        SELECT ${MEMBER_SELECT} FROM ins m JOIN users u ON u.id = m.user_id`,
       [randomUUID(), circleId, userId, position, status, reviewedAt]
     );
+
+    // Subscribe active member to Paystack recurring plan (best-effort)
+    if (status === "active" && circle.paystackPlanCode && paystackAuthCode) {
+      const { rows: userRows } = await q<{ email: string; id: string }>(
+        "SELECT id, email FROM users WHERE id = $1",
+        [userId]
+      );
+      const userEmail = userRows[0]?.email;
+      if (userEmail) {
+        try {
+          const { subscribeToPlan } = await import("@/lib/paystack");
+          const subscriptionCode = await subscribeToPlan({
+            email: userEmail,
+            planCode: circle.paystackPlanCode,
+            authorizationCode: paystackAuthCode,
+          });
+          await q(
+            "UPDATE members SET paystack_subscription_code = $1 WHERE id = $2",
+            [subscriptionCode, newMember[0].id]
+          );
+        } catch (err) {
+          console.error("[joinCircle] Paystack subscription failed:", err);
+        }
+      }
+    }
 
     // Auto-start when full (only count active members)
     const activeMembers = memberRows.filter(m => m.status === 'active').length + (status === 'active' ? 1 : 0);

--- a/src/server/services/notification.service.ts
+++ b/src/server/services/notification.service.ts
@@ -11,6 +11,7 @@ import {
   sendCircleCancelledNoRefundSms,
   sendCirclePausedSms,
   sendCircleResumedSms,
+  sendSubscriptionChargeFailedSms,
 } from "@/lib/sms";
 import type { User } from "@/types";
 
@@ -281,4 +282,22 @@ export async function notifyCircleResumed(
     }
   });
   await Promise.allSettled(notifications);
+}
+
+/**
+ * Notify a member when their Paystack subscription auto-charge fails
+ */
+export async function notifySubscriptionChargeFailed(
+  userId: string,
+  circleName: string,
+  amount: string
+): Promise<void> {
+  if (!(await canSendSms(userId))) return;
+  const phone = await getUserPhone(userId);
+  if (!phone) return;
+  try {
+    await sendSubscriptionChargeFailedSms(phone, circleName, amount);
+  } catch (error) {
+    console.error(`Failed to send charge-failed notification to ${userId}:`, error);
+  }
 }

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -20,6 +20,7 @@ export const joinCircleSchema = z.object({
   circleId: z.string().uuid(),
   stellarPublicKey: z.string().length(56, "Invalid Stellar public key"),
   token: z.string().optional(),
+  authorizationCode: z.string().optional(), // Paystack authorization code for recurring subscription
 });
 
 export const verifyOtpSchema = z.object({


### PR DESCRIPTION
## Summary

Resolves #310 — Add Paystack recurring payment plans for automated circle contributions.

## Acceptance Criteria

| Criterion | Implementation |
|-----------|---------------|
| ✅ Paystack plan created when circle is created | `createPlan()` called in `createCircle()`, plan code stored in `circles.paystack_plan_code` |
| ✅ Members subscribe to plan on join | `subscribeToPlan()` called in `joinCircle()` when `authorizationCode` provided, code stored in `members.paystack_subscription_code` |
| ✅ Subscription auto-charges on cycle date | Handled by Paystack's plan interval (weekly/biweekly/monthly mapped from `cycleFrequency`) |
| ✅ Failed charge triggers notification | `subscription.charge_failed` webhook event sends SMS via `notifySubscriptionChargeFailed()` |

## Changes

- **`src/lib/paystack.ts`** — Added `createPlan()`, `subscribeToPlan()`, `cancelSubscription()`
- **`src/server/services/circle.service.ts`** — `createCircle()` creates a Paystack plan (best-effort, non-blocking on failure); `joinCircle()` accepts optional `paystackAuthCode` and subscribes active members
- **`src/types/schemas.ts`** — Added optional `authorizationCode` to `joinCircleSchema`
- **`src/app/api/v1/circles/[id]/join/route.ts`** + legacy — Pass `authorizationCode` through to `joinCircle()`
- **`src/app/api/v1/webhooks/paystack/route.ts`** + legacy — Handle `subscription.charge_failed`: look up member by `paystack_subscription_code`, send SMS
- **`src/lib/sms.ts`** — Added `sendSubscriptionChargeFailedSms()`
- **`src/server/services/notification.service.ts`** — Added `notifySubscriptionChargeFailed()`
- **`migrations/1748700000000_add-paystack-recurring.ts`** — Adds `paystack_plan_code` to `circles`, `paystack_subscription_code` to `members`

## Notes

- Plan creation and subscription are best-effort: failures are logged but do not block circle creation or joining
- The client must obtain a Paystack `authorization_code` (from a prior transaction) and pass it in the join request body as `authorizationCode`
- `cancelSubscription()` is exported for future use when a member leaves or a circle is cancelled