### PR TITLE
feat: add Content Security Policy headers (#293)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,22 +4,24 @@ import { withSentryConfig } from "@sentry/nextjs";
 
 const cspHeader = [
   "default-src 'self'",
-  // Scripts: self + Next.js inline scripts (nonce not yet wired, so unsafe-inline in report-only)
-  "script-src 'self' 'unsafe-inline'",
+  // Scripts: self + trusted CDNs; unsafe-inline kept for Next.js inline scripts (report-only phase)
+  "script-src 'self' 'unsafe-inline' https://js.paystack.co https://cdn.vercel-insights.com",
   // Styles: self + inline (Next.js injects critical CSS)
   "style-src 'self' 'unsafe-inline'",
   // Images: self + data URIs
-  "img-src 'self' data:",
+  "img-src 'self' data: https:",
   // Fonts: self
   "font-src 'self'",
   // API / WebSocket connections restricted to known endpoints
-  "connect-src 'self' https://horizon.stellar.org https://horizon-testnet.stellar.org https://api.paystack.co https://api.ng.termii.com https://*.ingest.sentry.io",
+  "connect-src 'self' https://horizon.stellar.org https://horizon-testnet.stellar.org https://api.paystack.co https://api.ng.termii.com https://*.ingest.sentry.io https://vitals.vercel-insights.com",
   // No plugins
   "object-src 'none'",
   // Framing: deny
   "frame-ancestors 'none'",
   // Upgrade insecure requests in production
   "upgrade-insecure-requests",
+  // Report violations to /api/csp-report
+  "report-uri /api/csp-report",
 ].join("; ");
 
 const securityHeaders = [
@@ -28,6 +30,7 @@ const securityHeaders = [
   { key: "X-Content-Type-Options", value: "nosniff" },
   { key: "X-Frame-Options", value: "DENY" },
   { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  { key: "Strict-Transport-Security", value: "max-age=63072000; includeSubDomains; preload" },
 ];
 
 const nextConfig = {
@@ -35,19 +38,6 @@ const nextConfig = {
   experimental: {
     serverComponentsExternalPackages: ["@stellar/stellar-sdk"],
     instrumentationHook: true,
-  },
-  async headers() {
-    return [
-      {
-        source: "/(.*)",
-        headers: [
-          {
-            key: "Strict-Transport-Security",
-            value: "max-age=63072000; includeSubDomains; preload",
-          },
-        ],
-      },
-    ];
   },
   async redirects() {
     return process.env.NODE_ENV === "production"


### PR DESCRIPTION
Closes #293

## Changes
- Add `Content-Security-Policy-Report-Only` header with `script-src` restricted to self and trusted CDNs (Paystack, Vercel)
- Add `report-uri /api/csp-report` for violation reporting
- Fix duplicate `headers()` in next.config.mjs that was silently overriding HSTS
- Move HSTS into the consolidated `securityHeaders` array

## Testing
- No CSP violations expected in browser console for normal app usage
- Report-only mode means no enforcement yet — review violations before switching to `Content-Security-Policy`