### PR TITLE
feat: add k6 load test for payout endpoint (#291)

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -1,0 +1,52 @@
+name: Load Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Base URL to test against"
+        required: false
+        default: "http://localhost:3000"
+  push:
+    branches: [main]
+    paths:
+      - "k6/**"
+
+jobs:
+  load-test:
+    name: k6 Payout Load Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install k6
+        run: |
+          sudo gpg -k
+          sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg \
+            --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+          echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" \
+            | sudo tee /etc/apt/sources.list.d/k6.list
+          sudo apt-get update
+          sudo apt-get install -y k6
+
+      - name: Create results directory
+        run: mkdir -p k6-results
+
+      - name: Run payout load test
+        env:
+          BASE_URL: ${{ inputs.base_url || 'http://localhost:3000' }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET || 'ci-placeholder' }}
+        run: |
+          k6 run k6/payout-load-test.js \
+            --env BASE_URL=$BASE_URL \
+            --env CRON_SECRET=$CRON_SECRET \
+            --out json=k6-results/raw.json \
+            || true  # don't fail CI on threshold breach — just record results
+
+      - name: Upload k6 results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: k6-load-test-results
+          path: k6-results/
+          retention-days: 30

--- a/k6/payout-load-test.js
+++ b/k6/payout-load-test.js
@@ -1,0 +1,62 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Trend, Rate } from "k6/metrics";
+
+// Custom metrics
+const payoutDuration = new Trend("payout_duration", true);
+const payoutErrorRate = new Rate("payout_error_rate");
+
+export const options = {
+  // 50 concurrent virtual users
+  vus: 50,
+  duration: "30s",
+  thresholds: {
+    // p95 latency baseline: document actual value from first run
+    http_req_duration: ["p(95)<5000"],
+    payout_error_rate: ["rate<0.1"],
+  },
+};
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:3000";
+const CRON_SECRET = __ENV.CRON_SECRET || "test-secret";
+// Circle ID to use for load testing (set via env or use a test fixture)
+const CIRCLE_ID = __ENV.CIRCLE_ID || "test-circle-id";
+
+export default function () {
+  const res = http.post(
+    `${BASE_URL}/api/cron/cycle`,
+    JSON.stringify({ circleId: CIRCLE_ID }),
+    {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${CRON_SECRET}`,
+      },
+      timeout: "10s",
+    }
+  );
+
+  payoutDuration.add(res.timings.duration);
+  payoutErrorRate.add(res.status >= 500);
+
+  check(res, {
+    "status is not 5xx": (r) => r.status < 500,
+    "response has body": (r) => r.body && r.body.length > 0,
+  });
+
+  sleep(0.5);
+}
+
+export function handleSummary(data) {
+  const p95 = data.metrics.http_req_duration?.values?.["p(95)"];
+  console.log(`\n=== Payout Endpoint Load Test Results ===`);
+  console.log(`p95 latency: ${p95 ? p95.toFixed(2) + "ms" : "N/A"}`);
+  console.log(
+    `Error rate: ${(data.metrics.payout_error_rate?.values?.rate * 100 || 0).toFixed(2)}%`
+  );
+  console.log(`Total requests: ${data.metrics.http_reqs?.values?.count || 0}`);
+
+  return {
+    "k6-results/summary.json": JSON.stringify(data, null, 2),
+    stdout: "\n",
+  };
+}


### PR DESCRIPTION
Closes #291

## Changes
- Add `k6/payout-load-test.js`: 50 concurrent VUs over 30s against `/api/cron/cycle`
- Tracks p95 latency (`http_req_duration`) and error rate with thresholds
- Outputs `k6-results/summary.json` for baseline documentation
- Add `.github/workflows/load-test.yml`: runs on `workflow_dispatch` and pushes to `k6/`

## Running locally
```bash
k6 run k6/payout-load-test.js --env BASE_URL=http://localhost:3000 --env CRON_SECRET=your-secret
```

## CI
Results stored as `k6-load-test-results` artifact (30-day retention)