### PR TITLE
feat: optimistic UI for circle join action (#242)

### DIFF
--- a/src/components/circle/JoinCircleForm.tsx
+++ b/src/components/circle/JoinCircleForm.tsx
@@ -20,10 +20,10 @@ export function JoinCircleForm({ circle, token, inviteValid }: Props) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [optimisticJoined, setOptimisticJoined] = useState(false);
   const [noSavedKey, setNoSavedKey] = useState(false);
   const [stellarPublicKey, setStellarPublicKey] = useState("");
   const [optimisticCount, setOptimisticCount] = useState(circle.memberCount ?? 0);
-  const [noSavedKey, setNoSavedKey] = useState(false);
   const [hasUsdcTrustline, setHasUsdcTrustline] = useState<boolean | null>(null);
 
   const { connectionState, publicKey, error: walletError, connect, disconnect } = useFreighterWallet();
@@ -73,7 +73,8 @@ export function JoinCircleForm({ circle, token, inviteValid }: Props) {
     setLoading(true);
     setError(null);
 
-    // Optimistic update: increment member count immediately
+    // Optimistic updates: show joined state and increment member count immediately
+    setOptimisticJoined(true);
     setOptimisticCount((c) => c + 1);
 
     try {
@@ -93,7 +94,8 @@ export function JoinCircleForm({ circle, token, inviteValid }: Props) {
       router.push(`/circles/${circle.id}?joined=true`);
       router.refresh();
     } catch (err) {
-      // Revert optimistic update on error
+      // Revert optimistic updates on error
+      setOptimisticJoined(false);
       setOptimisticCount((c) => c - 1);
       setError(err instanceof Error ? err.message : "Failed to join circle");
     } finally {
@@ -180,9 +182,9 @@ export function JoinCircleForm({ circle, token, inviteValid }: Props) {
           type="submit"
           className="btn--full"
           loading={loading}
-          disabled={loading}
+          disabled={loading || optimisticJoined}
         >
-          {circle.circleType === "private" && !inviteValid ? "Request to Join" : "Join Circle"}
+          {optimisticJoined ? "Joined ✓" : circle.circleType === "private" && !inviteValid ? "Request to Join" : "Join Circle"}
         </Button>
       </form>
     </div>


### PR DESCRIPTION
Closes #242

## Changes
- Add `optimisticJoined` state to `JoinCircleForm`
- Join button immediately shows **"Joined ✓"** and is disabled on click (no waiting for API)
- Member count increments optimistically in the stats display
- On API error: both revert and error message shown as toast notification
- Existing `styles.toast` CSS (fixed bottom, fade-in animation) used for the error toast