### PR TITLE
feat(#261): implement background job queue for payout processing

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,10 @@
     "@stellar/stellar-sdk": "^12.3.0",
     "@tanstack/react-query": "^5.40.0",
     "axios": "^1.7.2",
+    "bullmq": "^5.7.8",
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",
+    "ioredis": "^5.3.2",
     "jose": "^5.6.3",
     "next": "14.2.4",
     "next-auth": "^4.24.7",
@@ -82,8 +84,6 @@
     "prettier": "^3.3.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.3"
-    "bullmq": "^1.81.0",
-    "ioredis": "^5.3.2"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/src/lib/queue/__tests__/payoutQueue.test.ts
+++ b/src/lib/queue/__tests__/payoutQueue.test.ts
@@ -1,0 +1,62 @@
+import { addPayoutJob, payoutQueue } from "../payoutQueue";
+
+// Mock IORedis and BullMQ so tests run without a real Redis instance
+jest.mock("ioredis", () => {
+  return jest.fn().mockImplementation(() => ({
+    on: jest.fn(),
+    quit: jest.fn(),
+  }));
+});
+
+jest.mock("bullmq", () => ({
+  Queue: jest.fn().mockImplementation(() => ({
+    add: jest.fn().mockResolvedValue({ id: "mock-job-id" }),
+  })),
+  Worker: jest.fn().mockImplementation(() => ({
+    on: jest.fn(),
+  })),
+}));
+
+jest.mock("@/server/config", () => ({
+  serverConfig: { redis: { url: "redis://localhost:6379" } },
+}));
+
+describe("payoutQueue", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("adds a payout job with correct data and options", async () => {
+    const job = await addPayoutJob("circle-1", 2);
+
+    expect(payoutQueue.add).toHaveBeenCalledWith(
+      "payout",
+      { circleId: "circle-1", cycleNumber: 2 },
+      {
+        jobId: "circle-1:2",
+        attempts: 3,
+        backoff: { type: "exponential", delay: 1000 },
+      }
+    );
+    expect(job).toEqual({ id: "mock-job-id" });
+  });
+
+  it("uses circleId:cycleNumber as jobId for deduplication", async () => {
+    await addPayoutJob("abc", 5);
+    expect(payoutQueue.add).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Object),
+      expect.objectContaining({ jobId: "abc:5" })
+    );
+  });
+
+  it("configures max 3 attempts with exponential backoff", async () => {
+    await addPayoutJob("circle-2", 1);
+    expect(payoutQueue.add).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Object),
+      expect.objectContaining({
+        attempts: 3,
+        backoff: { type: "exponential", delay: 1000 },
+      })
+    );
+  });
+});

--- a/src/lib/queue/__tests__/worker.test.ts
+++ b/src/lib/queue/__tests__/worker.test.ts
@@ -1,0 +1,83 @@
+import { Worker } from "bullmq";
+
+// Capture the worker processor function so we can invoke it directly
+let capturedProcessor: ((job: unknown) => Promise<unknown>) | null = null;
+const mockWorkerOn = jest.fn();
+
+jest.mock("ioredis", () =>
+  jest.fn().mockImplementation(() => ({ on: jest.fn(), quit: jest.fn() }))
+);
+
+jest.mock("bullmq", () => ({
+  Queue: jest.fn().mockImplementation(() => ({ add: jest.fn() })),
+  Worker: jest.fn().mockImplementation((_, processor, __) => {
+    capturedProcessor = processor;
+    return { on: mockWorkerOn };
+  }),
+}));
+
+jest.mock("@/server/config", () => ({
+  serverConfig: { redis: { url: "redis://localhost:6379" } },
+}));
+
+const mockQuery = jest.fn();
+jest.mock("@/lib/db", () => ({ query: (...args: unknown[]) => mockQuery(...args) }));
+
+const mockProcessCyclePayout = jest.fn();
+jest.mock("@/server/services/payout.service", () => ({
+  processCyclePayout: (...args: unknown[]) => mockProcessCyclePayout(...args),
+}));
+
+// Import worker after mocks are set up so the module-level Worker() call is captured
+import "../worker";
+
+describe("payout worker", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("registers active, completed, and failed event listeners", () => {
+    expect(mockWorkerOn).toHaveBeenCalledWith("active", expect.any(Function));
+    expect(mockWorkerOn).toHaveBeenCalledWith("completed", expect.any(Function));
+    expect(mockWorkerOn).toHaveBeenCalledWith("failed", expect.any(Function));
+  });
+
+  it("processes a job by resolving the stellar key and calling processCyclePayout", async () => {
+    mockQuery.mockResolvedValue({ rows: [{ stellar_public_key: "GABC123" }] });
+    mockProcessCyclePayout.mockResolvedValue(undefined);
+
+    const job = { id: "job-1", data: { circleId: "circle-1", cycleNumber: 1 } };
+    const result = await capturedProcessor!(job);
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("stellar_public_key"),
+      ["circle-1", 1]
+    );
+    expect(mockProcessCyclePayout).toHaveBeenCalledWith("circle-1", "GABC123");
+    expect(result).toEqual({ success: true });
+  });
+
+  it("falls back to empty string when no stellar key is found", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+    mockProcessCyclePayout.mockResolvedValue(undefined);
+
+    const job = { id: "job-2", data: { circleId: "circle-2", cycleNumber: 2 } };
+    await capturedProcessor!(job);
+
+    expect(mockProcessCyclePayout).toHaveBeenCalledWith("circle-2", "");
+  });
+
+  it("re-throws errors so BullMQ can apply retry backoff", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+    mockProcessCyclePayout.mockRejectedValue(new Error("payout failed"));
+
+    const job = { id: "job-3", data: { circleId: "circle-3", cycleNumber: 3 } };
+    await expect(capturedProcessor!(job)).rejects.toThrow("payout failed");
+  });
+
+  it("creates a Worker with concurrency 1", () => {
+    expect(Worker).toHaveBeenCalledWith(
+      "payouts",
+      expect.any(Function),
+      expect.objectContaining({ concurrency: 1 })
+    );
+  });
+});

--- a/src/lib/queue/payoutQueue.ts
+++ b/src/lib/queue/payoutQueue.ts
@@ -1,9 +1,12 @@
 import { Queue } from "bullmq";
+import IORedis from "ioredis";
 import { serverConfig } from "@/server/config";
 
-const connection = { connection: { url: serverConfig.redis.url } };
+export const redisConnection = new IORedis(serverConfig.redis.url, {
+  maxRetriesPerRequest: null,
+});
 
-export const payoutQueue = new Queue("payouts", connection);
+export const payoutQueue = new Queue("payouts", { connection: redisConnection });
 
 export async function addPayoutJob(circleId: string, cycleNumber: number) {
   return payoutQueue.add(

--- a/src/lib/queue/worker.ts
+++ b/src/lib/queue/worker.ts
@@ -1,12 +1,7 @@
-import { Worker, QueueScheduler } from "bullmq";
-import { serverConfig } from "@/server/config";
+import { Worker } from "bullmq";
+import { redisConnection } from "./payoutQueue";
 import { processCyclePayout } from "@/server/services/payout.service";
 import { query } from "@/lib/db";
-
-const connection = { connection: { url: serverConfig.redis.url } };
-
-// Ensure stalled jobs are reprocessed and repeatable jobs work correctly
-new QueueScheduler("payouts", connection);
 
 const worker = new Worker(
   "payouts",
@@ -14,7 +9,6 @@ const worker = new Worker(
     const { circleId, cycleNumber } = job.data as { circleId: string; cycleNumber: number };
     console.log(`[payout-worker] Starting job ${job.id} for ${circleId}:${cycleNumber}`);
 
-    // Resolve recipient Stellar key if needed (Horizon path)
     const { rows } = await query<{ stellar_public_key: string | null }>(
       `SELECT u.stellar_public_key
        FROM members m
@@ -24,28 +18,23 @@ const worker = new Worker(
     );
     const stellarKey = rows[0]?.stellar_public_key ?? "";
 
-    try {
-      await processCyclePayout(circleId, stellarKey);
-      console.log(`[payout-worker] Completed job ${job.id} for ${circleId}:${cycleNumber}`);
-      return { success: true };
-    } catch (err) {
-      console.error(`[payout-worker] Failed job ${job.id} for ${circleId}:${cycleNumber}:`, err);
-      throw err;
-    }
+    await processCyclePayout(circleId, stellarKey);
+    console.log(`[payout-worker] Completed job ${job.id} for ${circleId}:${cycleNumber}`);
+    return { success: true };
   },
-  { connection, concurrency: 1 }
+  { connection: redisConnection, concurrency: 1 }
 );
 
 worker.on("active", (job) => {
-  console.log(`[payout-worker] Job ${job.id} is active for ${job.data.circleId}:${job.data.cycleNumber}`);
+  console.log(`[payout-worker] Job ${job.id} active: ${job.data.circleId}:${job.data.cycleNumber}`);
 });
 
 worker.on("completed", (job) => {
-  console.log(`[payout-worker] Job ${job.id} completed for ${job.data.circleId}:${job.data.cycleNumber}`);
+  console.log(`[payout-worker] Job ${job.id} completed: ${job.data.circleId}:${job.data.cycleNumber}`);
 });
 
 worker.on("failed", (job, err) => {
-  console.error(`[payout-worker] Job ${job?.id} failed for ${job?.data?.circleId}:${job?.data?.cycleNumber}`, err);
+  console.error(`[payout-worker] Job ${job?.id} failed: ${job?.data?.circleId}:${job?.data?.cycleNumber}`, err);
 });
 
 export default worker;


### PR DESCRIPTION
Title: feat(#261): implement background job queue for payout processing
  
  Description:
  
  Summary
  
  Closes #261 
  
  Moves payout processing out of the synchronous cron handler into a BullMQ background job queue,
  eliminating timeout risk on long-running Stellar transactions.
  
  Changes
  
  - payoutQueue.ts — Fixed Redis connection to use an IORedis instance (maxRetriesPerRequest: null required
  by BullMQ). Exports shared redisConnection.
  - worker.ts — Removed QueueScheduler (dropped in BullMQ v2+). Worker shares the IORedis connection,
  re-throws errors so BullMQ applies retry backoff.
  - package.json — Moved bullmq@^5.7.8 and ioredis@^5.3.2 from devDependencies to dependencies. Fixed JSON
  syntax error.
  - Tests — Added payoutQueue.test.ts and worker.test.ts covering job enqueue options, deduplication,
  backoff config, stellar key resolution, and error re-throw.
  
  Acceptance Criteria
  
  - [x] BullMQ queue set up for payout jobs
  - [x] Cron enqueues jobs instead of processing inline
  - [x] Failed jobs retry with exponential backoff (max 3 retries, 1s base delay)
  - [x] Job status visible in logs (active, completed, failed events)
  
  Testing
  
  Run npm test src/lib/queue after npm install.

