### PR TITLE
feat(#129): KYC verification gate for high-value circles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -136,6 +136,23 @@ TERMII_SENDER_ID=Ajosave
 # Format: redis://username:password@host:port or rediss:// for TLS
 REDIS_URL=redis://localhost:6379
 
+# ─── KYC (Smile Identity) — Issue #129 ────────────────────────────────────────
+# [REQUIRED for KYC] Smile Identity partner ID
+# How to get: https://portal.smileidentity.com → Settings → API Keys
+SMILE_PARTNER_ID=replace_with_smile_partner_id
+
+# [REQUIRED for KYC] Smile Identity API key (used to sign webhook payloads)
+# ⚠️  SECURITY: Never commit this to git.
+SMILE_API_KEY=replace_with_smile_api_key
+
+# [REQUIRED for KYC] Full public URL that Smile Identity calls with verification results
+# Example: https://yourdomain.com/api/v1/kyc/webhook
+SMILE_CALLBACK_URL=https://yourdomain.com/api/v1/kyc/webhook
+
+# [OPTIONAL] NGN contribution amount above which KYC is required (default: 100000)
+# Circles with contribution_fiat >= this value will block unverified users.
+KYC_THRESHOLD_NGN=100000
+
 # ─── Cron Jobs ─────────────────────────────────────────────────────────────────
 # [REQUIRED] Secret token for authenticating cron job requests
 # Purpose: Prevents unauthorized access to scheduled payout endpoints

--- a/migrations/1749100000000_add-kyc-fields.ts
+++ b/migrations/1749100000000_add-kyc-fields.ts
@@ -1,0 +1,35 @@
+/**
+ * Migration: KYC fields on users and KYC threshold on circles (Issue #129)
+ *
+ * - users.kyc_status      — enum-like varchar: 'none' | 'pending' | 'approved' | 'rejected'
+ * - users.kyc_verified_at — timestamp set when status transitions to 'approved'
+ * - circles.kyc_threshold — optional NGN amount; if set, joining requires kyc_status = 'approved'
+ */
+import { MigrationBuilder } from "node-pg-migrate";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumns("users", {
+    kyc_status: {
+      type: "varchar(20)",
+      notNull: true,
+      default: "none",
+      check: "kyc_status IN ('none','pending','approved','rejected')",
+    },
+    kyc_verified_at: { type: "timestamp" },
+  });
+
+  pgm.addColumns("circles", {
+    kyc_threshold: {
+      type: "numeric(20,2)",
+      comment: "NGN contribution amount above which KYC is required to join. NULL = no requirement.",
+    },
+  });
+
+  pgm.createIndex("users", "kyc_status");
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex("users", "kyc_status", { ifExists: true });
+  pgm.dropColumns("circles", ["kyc_threshold"]);
+  pgm.dropColumns("users", ["kyc_status", "kyc_verified_at"]);
+}

--- a/src/app/api/v1/circles/[id]/join/route.ts
+++ b/src/app/api/v1/circles/[id]/join/route.ts
@@ -6,6 +6,8 @@ import { joinCircle, getCircleById } from "@/server/services/circle.service";
 import { withErrorHandler } from "@/server/middleware";
 import { verifyInviteToken } from "@/lib/tokens";
 import { checkReputationGate } from "@/server/services/reputation.service";
+import { isKycVerified } from "@/lib/kyc";
+import { serverConfig } from "@/server/config";
 import type { ApiResponse, Member } from "@/types";
 
 export const POST = withErrorHandler(async (req: NextRequest, ctx: unknown) => {
@@ -17,6 +19,7 @@ export const POST = withErrorHandler(async (req: NextRequest, ctx: unknown) => {
     );
   }
 
+  const userId = (session.user as { id: string }).id;
   const { params } = ctx as { params: { id: string } };
   const body = await req.json();
   const parsed = joinCircleSchema.safeParse({ ...body, circleId: params.id });
@@ -53,14 +56,11 @@ export const POST = withErrorHandler(async (req: NextRequest, ctx: unknown) => {
     }
     isInvited = true;
   } else if (token) {
-    // Also check token for public circles if provided
     const decoded = await verifyInviteToken(token);
-    if (decoded && decoded.circleId === params.id) {
-      isInvited = true;
-    }
+    if (decoded && decoded.circleId === params.id) isInvited = true;
   }
 
-  // Check reputation gate if circle has minimum reputation requirement
+  // ── Reputation gate ───────────────────────────────────────────────────────
   if (circle.minReputation && circle.minReputation > 0) {
     const { eligible, currentScore } = await checkReputationGate(userId, circle.minReputation);
     if (!eligible) {
@@ -74,7 +74,32 @@ export const POST = withErrorHandler(async (req: NextRequest, ctx: unknown) => {
     }
   }
 
-  const userId = (session.user as { id: string }).id;
+  // ── KYC gate ──────────────────────────────────────────────────────────────
+  // A circle triggers KYC if its own kyc_threshold is set, OR if the
+  // contribution amount meets the global KYC_THRESHOLD_NGN.
+  const circleThreshold = (circle as { kycThreshold?: number | null }).kycThreshold;
+  const globalThreshold = serverConfig.kyc.thresholdNgn;
+  const contributionNgn = typeof circle.contributionFiat === "number"
+    ? circle.contributionFiat
+    : parseFloat(circle.contributionFiat as unknown as string) || 0;
+  const effectiveThreshold = circleThreshold ?? globalThreshold;
+
+  if (contributionNgn >= effectiveThreshold) {
+    const verified = await isKycVerified(userId);
+    if (!verified) {
+      return NextResponse.json<ApiResponse<never>>(
+        {
+          success: false,
+          error: "Identity verification (KYC) is required to join circles above ₦" +
+            effectiveThreshold.toLocaleString() +
+            ". Please complete verification at /api/v1/kyc/verify.",
+          code: "KYC_REQUIRED",
+        },
+        { status: 403 }
+      );
+    }
+  }
+
   const member = await joinCircle(params.id, userId, isInvited);
   return NextResponse.json<ApiResponse<Member>>({ success: true, data: member }, { status: 201 });
 });

--- a/src/app/api/v1/kyc/verify/route.ts
+++ b/src/app/api/v1/kyc/verify/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { initiateKyc } from "@/lib/kyc";
+import { withErrorHandler } from "@/server/middleware";
+import type { ApiResponse } from "@/types";
+
+/**
+ * POST /api/v1/kyc/verify
+ * Initiates a KYC session for the authenticated user.
+ * Returns a Smile Identity web-token the client passes to the widget SDK.
+ */
+export const POST = withErrorHandler(async () => {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  const userId = (session.user as { id: string }).id;
+  const { token } = await initiateKyc(userId);
+
+  return NextResponse.json<ApiResponse<{ token: string }>>({
+    success: true,
+    data: { token },
+  });
+});

--- a/src/app/api/v1/kyc/webhook/route.ts
+++ b/src/app/api/v1/kyc/webhook/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { handleKycWebhook, type SmileWebhookPayload } from "@/lib/kyc";
+import { withErrorHandler } from "@/server/middleware";
+import type { ApiResponse } from "@/types";
+
+/**
+ * POST /api/v1/kyc/webhook
+ * Receives KYC result callbacks from Smile Identity.
+ * Verifies the HMAC signature and updates the user's kyc_status.
+ */
+export const POST = withErrorHandler(async (req: NextRequest) => {
+  const payload = (await req.json()) as SmileWebhookPayload;
+
+  if (!payload?.PartnerParams?.user_id || !payload.signature || !payload.timestamp) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Invalid payload" },
+      { status: 400 }
+    );
+  }
+
+  const { userId, status } = await handleKycWebhook(payload);
+
+  return NextResponse.json<ApiResponse<{ userId: string; status: string }>>({
+    success: true,
+    data: { userId, status },
+  });
+});

--- a/src/lib/__tests__/kyc-gate.test.ts
+++ b/src/lib/__tests__/kyc-gate.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for KYC gate logic — Issue #129
+ *
+ * Tests the core decision logic: given a circle's contribution amount and a
+ * user's KYC status, should the join be blocked?
+ */
+
+// ── Inline the gate logic so we can test it without DB/network ───────────────
+
+type KycStatus = "none" | "pending" | "approved" | "rejected";
+
+function shouldBlockJoin(params: {
+  contributionNgn: number;
+  effectiveThreshold: number;
+  kycStatus: KycStatus;
+}): boolean {
+  const { contributionNgn, effectiveThreshold, kycStatus } = params;
+  if (contributionNgn < effectiveThreshold) return false;
+  return kycStatus !== "approved";
+}
+
+function resolveThreshold(
+  circleThreshold: number | null | undefined,
+  globalThreshold: number
+): number {
+  return circleThreshold ?? globalThreshold;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("KYC gate — shouldBlockJoin", () => {
+  const threshold = 100_000;
+
+  it("allows verified users on high-value circles", () => {
+    expect(shouldBlockJoin({ contributionNgn: 150_000, effectiveThreshold: threshold, kycStatus: "approved" })).toBe(false);
+  });
+
+  it("blocks unverified (none) users on high-value circles", () => {
+    expect(shouldBlockJoin({ contributionNgn: 150_000, effectiveThreshold: threshold, kycStatus: "none" })).toBe(true);
+  });
+
+  it("blocks pending users on high-value circles", () => {
+    expect(shouldBlockJoin({ contributionNgn: 100_000, effectiveThreshold: threshold, kycStatus: "pending" })).toBe(true);
+  });
+
+  it("blocks rejected users on high-value circles", () => {
+    expect(shouldBlockJoin({ contributionNgn: 200_000, effectiveThreshold: threshold, kycStatus: "rejected" })).toBe(true);
+  });
+
+  it("allows unverified users below the threshold", () => {
+    expect(shouldBlockJoin({ contributionNgn: 50_000, effectiveThreshold: threshold, kycStatus: "none" })).toBe(false);
+  });
+
+  it("blocks at exactly the threshold amount", () => {
+    expect(shouldBlockJoin({ contributionNgn: 100_000, effectiveThreshold: threshold, kycStatus: "none" })).toBe(true);
+  });
+
+  it("allows verified users below the threshold", () => {
+    expect(shouldBlockJoin({ contributionNgn: 99_999, effectiveThreshold: threshold, kycStatus: "approved" })).toBe(false);
+  });
+});
+
+describe("KYC gate — resolveThreshold", () => {
+  const global = 100_000;
+
+  it("uses per-circle threshold when set", () => {
+    expect(resolveThreshold(50_000, global)).toBe(50_000);
+  });
+
+  it("falls back to global threshold when circle has no override", () => {
+    expect(resolveThreshold(null, global)).toBe(global);
+    expect(resolveThreshold(undefined, global)).toBe(global);
+  });
+
+  it("respects a zero per-circle threshold (always require KYC)", () => {
+    expect(resolveThreshold(0, global)).toBe(0);
+  });
+});

--- a/src/lib/kyc.ts
+++ b/src/lib/kyc.ts
@@ -1,0 +1,115 @@
+/**
+ * KYC integration — Issue #129
+ *
+ * Thin wrapper around the Smile Identity Web API v2.
+ * Flow:
+ *   1. Client calls POST /api/v1/kyc/verify  → server calls initiateKyc()
+ *      → returns a Smile Identity web-token the client uses to open the widget.
+ *   2. Smile Identity calls POST /api/v1/kyc/webhook with the result.
+ *   3. handleKycWebhook() verifies the HMAC signature and upserts kyc_status.
+ *
+ * Required env vars:
+ *   SMILE_PARTNER_ID    — your Smile Identity partner ID
+ *   SMILE_API_KEY       — Smile Identity API key (used for HMAC verification)
+ *   SMILE_CALLBACK_URL  — full URL to /api/v1/kyc/webhook
+ */
+import { createHmac } from "crypto";
+import { query } from "./db";
+
+const BASE_URL = "https://testapi.smileidentity.com/v1";
+
+export type KycStatus = "none" | "pending" | "approved" | "rejected";
+
+/** Initiate a KYC session; returns the web-token for the Smile Identity widget. */
+export async function initiateKyc(userId: string): Promise<{ token: string }> {
+  const partnerId = requireEnv("SMILE_PARTNER_ID");
+  const apiKey = requireEnv("SMILE_API_KEY");
+  const callbackUrl = requireEnv("SMILE_CALLBACK_URL");
+
+  const res = await fetch(`${BASE_URL}/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      partner_id: partnerId,
+      api_key: apiKey,
+      callback_url: callbackUrl,
+      user_id: userId,
+      product: "ekyc_smartselfie",
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Smile Identity token request failed: ${text}`);
+  }
+
+  const data = (await res.json()) as { token: string };
+
+  // Mark user as pending
+  await query(
+    "UPDATE users SET kyc_status = 'pending' WHERE id = $1",
+    [userId]
+  );
+
+  return { token: data.token };
+}
+
+export interface SmileWebhookPayload {
+  ResultCode: string;       // "1012" = Approved, "1020" = Rejected, etc.
+  PartnerParams: { user_id: string };
+  signature: string;
+  timestamp: string;
+}
+
+/**
+ * Verify the Smile Identity HMAC signature and update kyc_status.
+ * Returns the resolved status so the route can respond accordingly.
+ */
+export async function handleKycWebhook(
+  payload: SmileWebhookPayload
+): Promise<{ userId: string; status: KycStatus }> {
+  const apiKey = requireEnv("SMILE_API_KEY");
+  const partnerId = requireEnv("SMILE_PARTNER_ID");
+
+  // Smile Identity signature: HMAC-SHA256 of "timestamp:partner_id"
+  const expected = createHmac("sha256", apiKey)
+    .update(`${payload.timestamp}:${partnerId}`)
+    .digest("base64");
+
+  if (expected !== payload.signature) {
+    throw new Error("Invalid Smile Identity webhook signature");
+  }
+
+  const userId = payload.PartnerParams.user_id;
+  // ResultCode "1012" = Approved; anything else is treated as rejected
+  const status: KycStatus = payload.ResultCode === "1012" ? "approved" : "rejected";
+
+  await query(
+    `UPDATE users
+     SET kyc_status = $1, kyc_verified_at = CASE WHEN $1 = 'approved' THEN NOW() ELSE NULL END
+     WHERE id = $2`,
+    [status, userId]
+  );
+
+  return { userId, status };
+}
+
+/** Returns the current KYC status for a user. */
+export async function getKycStatus(userId: string): Promise<KycStatus> {
+  const { rows } = await query<{ kyc_status: KycStatus }>(
+    "SELECT kyc_status FROM users WHERE id = $1",
+    [userId]
+  );
+  return rows[0]?.kyc_status ?? "none";
+}
+
+/** True if the user has approved KYC. */
+export async function isKycVerified(userId: string): Promise<boolean> {
+  return (await getKycStatus(userId)) === "approved";
+}
+
+function requireEnv(name: string): string {
+  const val = process.env[name];
+  if (!val) throw new Error(`Missing required env var: ${name}`);
+  return val;
+}

--- a/src/server/config/index.ts
+++ b/src/server/config/index.ts
@@ -34,4 +34,11 @@ export const serverConfig = {
   database: { url: process.env.DATABASE_URL ?? "" },
   cronSecret: process.env.CRON_SECRET ?? "",
   authSecret: process.env.NEXTAUTH_SECRET ?? "development-secret-keep-it-safe",
+  kyc: {
+    smilePartnerId: process.env.SMILE_PARTNER_ID ?? "",
+    smileApiKey: process.env.SMILE_API_KEY ?? "",
+    smileCallbackUrl: process.env.SMILE_CALLBACK_URL ?? "",
+    /** NGN threshold above which circles require KYC (default 100,000) */
+    thresholdNgn: parseInt(process.env.KYC_THRESHOLD_NGN ?? "100000", 10),
+  },
 } as const;


### PR DESCRIPTION
## Summary

Closes #129

Circles with a contribution amount at or above the KYC threshold require identity verification (Smile Identity) before a user can join.

## Changes

- **`src/lib/kyc.ts`** — Smile Identity integration: `initiateKyc()` (returns widget token), `handleKycWebhook()` (HMAC verify + DB upsert), `isKycVerified()`
- **`migrations/1749100000000_add-kyc-fields.ts`** — adds `kyc_status` + `kyc_verified_at` to `users`; `kyc_threshold` (per-circle override) to `circles`
- **`POST /api/v1/kyc/verify`** — initiates a KYC session, returns Smile Identity web-token
- **`POST /api/v1/kyc/webhook`** — receives Smile Identity callback, verifies HMAC signature, upserts `kyc_status`
- **`src/app/api/v1/circles/[id]/join/route.ts`** — KYC gate blocks `none/pending/rejected` users on high-value circles; returns `403 KYC_REQUIRED`; also fixes pre-existing `userId` used-before-declaration bug
- **`.env.example`** / **`serverConfig`** — documents `SMILE_PARTNER_ID`, `SMILE_API_KEY`, `SMILE_CALLBACK_URL`, `KYC_THRESHOLD_NGN` (default 100,000 NGN)

## Acceptance Criteria

- [x] KYC threshold configurable via `KYC_THRESHOLD_NGN` env var (default 100k NGN) and per-circle `kyc_threshold` column
- [x] KYC provider integrated (Smile Identity Web API v2)
- [x] KYC status stored on user record (`kyc_status`, `kyc_verified_at`)
- [x] Unverified users blocked from high-value circles (`403 KYC_REQUIRED`)

## Testing

10 unit tests — all passing:
```
npm test -- --testPathPattern=kyc-gate
```