### PR TITLE
feat(#130): testnet faucet — fund XLM + USDC in one step

### DIFF
--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -445,3 +445,47 @@ SELECT * FROM payouts WHERE circle_id = $1 ORDER BY cycle_number;
 | Production deployment | 10 min |
 | Post-deployment monitoring | Ongoing |
 | **Total** | **~50 minutes** |
+
+---
+
+## Testnet Faucet (Development Only)
+
+When `STELLAR_NETWORK=testnet`, a built-in faucet endpoint lets developers fund a Stellar account with testnet XLM and USDC in one step.
+
+### API
+
+```
+POST /api/stellar/faucet
+Content-Type: application/json
+Authorization: session cookie (must be logged in)
+
+{ "publicKey": "G..." }
+```
+
+**Response**
+```json
+{ "success": true, "data": { "xlmFunded": true, "usdcTxHash": "abc123..." } }
+```
+
+Blocked with `403` on mainnet.
+
+### UI Button
+
+The `FundTestnetButton` component (at `src/components/wallet/FundTestnetButton.tsx`) renders only when `NEXT_PUBLIC_STELLAR_NETWORK=testnet`. Add it to any wallet-connected page:
+
+```tsx
+import FundTestnetButton from "@/components/wallet/FundTestnetButton";
+
+<FundTestnetButton publicKey={stellarPublicKey} onSuccess={(txHash) => console.log(txHash)} />
+```
+
+### Rate Limiting
+
+The endpoint is rate-limited to **5 requests per 10 minutes** per IP to prevent abuse.
+
+### What it does
+
+1. Calls Friendbot (`https://friendbot.stellar.org?addr=<key>`) to create the account and fund it with 10,000 XLM.
+2. Sends **100 USDC** from the server wallet to the account.
+
+> **Requirement:** The server wallet (`STELLAR_SERVER_SECRET_KEY`) must hold a USDC trustline and sufficient balance. Fund it once via [Stellar Laboratory](https://laboratory.stellar.org) on testnet.

--- a/src/app/api/stellar/faucet/route.ts
+++ b/src/app/api/stellar/faucet/route.ts
@@ -1,0 +1,69 @@
+/**
+ * POST /api/stellar/faucet
+ *
+ * Testnet-only endpoint. Funds the given Stellar public key with:
+ *   1. 10,000 XLM via Friendbot (creates the account if needed)
+ *   2. 100 USDC from the server wallet
+ *
+ * Blocked entirely on mainnet.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { sendUsdcPayment } from "@/lib/stellar";
+import { serverConfig } from "@/server/config";
+import { withRateLimit, withErrorHandler } from "@/server/middleware";
+import type { ApiResponse } from "@/types";
+
+const USDC_FAUCET_AMOUNT = "100"; // USDC to send from server wallet
+const FRIENDBOT_URL = "https://friendbot.stellar.org";
+
+async function handler(req: NextRequest): Promise<NextResponse> {
+  if (serverConfig.stellar.network !== "testnet") {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Faucet is only available on testnet" },
+      { status: 403 }
+    );
+  }
+
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  const { publicKey } = await req.json();
+  if (!publicKey || !/^G[A-Z2-7]{55}$/.test(publicKey)) {
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: "Invalid Stellar public key" },
+      { status: 400 }
+    );
+  }
+
+  // Step 1 — fund XLM via Friendbot (creates account + adds XLM)
+  const friendbotRes = await fetch(`${FRIENDBOT_URL}?addr=${encodeURIComponent(publicKey)}`);
+  if (!friendbotRes.ok && friendbotRes.status !== 400) {
+    // 400 from Friendbot means account already funded — that's fine
+    const text = await friendbotRes.text();
+    return NextResponse.json<ApiResponse<never>>(
+      { success: false, error: `Friendbot error: ${text}` },
+      { status: 502 }
+    );
+  }
+
+  // Step 2 — send USDC from server wallet
+  const txHash = await sendUsdcPayment(publicKey, USDC_FAUCET_AMOUNT);
+
+  return NextResponse.json<ApiResponse<{ xlmFunded: boolean; usdcTxHash: string }>>({
+    success: true,
+    data: { xlmFunded: true, usdcTxHash: txHash },
+  });
+}
+
+// 5 requests per 10 minutes per IP — enough for dev, prevents abuse
+export const POST = withRateLimit(withErrorHandler(handler), {
+  limit: 5,
+  windowMs: 10 * 60 * 1000,
+});

--- a/src/components/wallet/FundTestnetButton.tsx
+++ b/src/components/wallet/FundTestnetButton.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState } from "react";
+
+interface Props {
+  publicKey: string;
+  onSuccess?: (usdcTxHash: string) => void;
+}
+
+/**
+ * Rendered only when NEXT_PUBLIC_STELLAR_NETWORK=testnet.
+ * Calls the faucet endpoint to fund the given Stellar account with XLM + USDC.
+ */
+export default function FundTestnetButton({ publicKey, onSuccess }: Props) {
+  if (process.env.NEXT_PUBLIC_STELLAR_NETWORK !== "testnet") return null;
+
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+
+  async function handleFund() {
+    setLoading(true);
+    setMessage(null);
+    try {
+      const res = await fetch("/api/stellar/faucet", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ publicKey }),
+      });
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error);
+      setMessage({ type: "success", text: `Funded! USDC tx: ${json.data.usdcTxHash.slice(0, 16)}…` });
+      onSuccess?.(json.data.usdcTxHash);
+    } catch (err: unknown) {
+      setMessage({ type: "error", text: err instanceof Error ? err.message : "Faucet failed" });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div style={{ marginTop: "0.5rem" }}>
+      <button
+        onClick={handleFund}
+        disabled={loading || !publicKey}
+        style={{
+          background: "#f59e0b",
+          color: "#fff",
+          border: "none",
+          borderRadius: "6px",
+          padding: "0.4rem 1rem",
+          cursor: loading ? "not-allowed" : "pointer",
+          fontSize: "0.85rem",
+          opacity: loading || !publicKey ? 0.6 : 1,
+        }}
+      >
+        {loading ? "Funding…" : "🪙 Fund testnet account (XLM + USDC)"}
+      </button>
+      {message && (
+        <p style={{ marginTop: "0.25rem", fontSize: "0.8rem", color: message.type === "success" ? "green" : "red" }}>
+          {message.text}
+        </p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #130

Adds a dev-mode faucet so developers can fund a testnet Stellar account with XLM and USDC in one API call or button click.

## Changes

- **`POST /api/stellar/faucet`** — testnet-only endpoint; calls Friendbot for 10k XLM, then sends 100 USDC from the server wallet. Returns `403` on mainnet. Rate-limited to 5 req/10min.
- **`FundTestnetButton`** (`src/components/wallet/FundTestnetButton.tsx`) — client component that renders only when `NEXT_PUBLIC_STELLAR_NETWORK=testnet`
- **`docs/DEPLOYMENT_GUIDE.md`** — faucet API docs, UI usage, and server wallet setup note

## Acceptance Criteria

- [x] Dev-mode button to fund testnet account with XLM and USDC
- [x] Only available when `STELLAR_NETWORK=testnet`
- [x] Documented in developer guide