### PR TITLE
feat: resolve issues #312, #327, #332, #331

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,11 @@ STELLAR_NETWORK=testnet
 # Mainnet: https://horizon.stellar.org
 STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 
+# [OPTIONAL] Secondary Horizon API endpoint for failover redundancy
+# If the primary fails, requests will automatically retry against this URL
+# Mainnet fallback: https://horizon.stellar.org (SDF) or https://horizon.stellar.lobstr.co
+STELLAR_HORIZON_FALLBACK_URL=
+
 # [REQUIRED] Network passphrase for transaction signing
 # Purpose: Ensures transactions are signed for the correct network
 # Testnet: "Test SDF Network ; September 2015"

--- a/migrations/1748600000000_add-payout-status.ts
+++ b/migrations/1748600000000_add-payout-status.ts
@@ -1,0 +1,19 @@
+import { Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable("payouts")
+    .addColumn("status", "varchar(20)", (col) => col.notNull().defaultTo("completed"))
+    .addColumn("retry_count", "integer", (col) => col.notNull().defaultTo(0))
+    .addColumn("last_error", "text")
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable("payouts")
+    .dropColumn("status")
+    .dropColumn("retry_count")
+    .dropColumn("last_error")
+    .execute();
+}

--- a/src/app/api/admin/payouts/[id]/retry/route.ts
+++ b/src/app/api/admin/payouts/[id]/retry/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAdminAuth, withErrorHandler } from "@/server/middleware";
+import { query } from "@/lib/db";
+import { processCyclePayout } from "@/server/services/payout.service";
+import type { ApiResponse, Payout } from "@/types";
+
+export const POST = withErrorHandler(
+  withAdminAuth(async (_req: NextRequest, ctx: unknown) => {
+    const { params } = ctx as { params: { id: string } };
+
+    const { rows } = await query<{ circle_id: string; cycle_number: number; status: string; recipient_stellar_key: string | null }>(
+      `SELECT p.circle_id, p.cycle_number, p.status,
+              u.stellar_public_key AS recipient_stellar_key
+       FROM payouts p
+       JOIN members m ON m.id = p.recipient_member_id
+       JOIN users u ON u.id = m.user_id
+       WHERE p.id = $1`,
+      [params.id]
+    );
+    const row = rows[0];
+    if (!row) return NextResponse.json<ApiResponse<never>>({ success: false, error: "Payout not found" }, { status: 404 });
+    if (row.status !== "failed") return NextResponse.json<ApiResponse<never>>({ success: false, error: "Only failed payouts can be retried" }, { status: 400 });
+
+    // Reset retry count so it gets full retries again
+    await query("UPDATE payouts SET retry_count = 0, status = 'pending' WHERE id = $1", [params.id]);
+
+    const payout = await processCyclePayout(row.circle_id, row.recipient_stellar_key ?? "");
+    return NextResponse.json<ApiResponse<Payout>>({ success: true, data: payout });
+  })
+);

--- a/src/app/api/v1/health/route.ts
+++ b/src/app/api/v1/health/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { query, getPoolStats } from "@/lib/db";
 import { serverConfig } from "@/server/config";
+import { checkHorizonHealth } from "@/lib/stellar";
 
 async function checkDb(): Promise<boolean> {
   try {
@@ -25,7 +26,7 @@ async function checkRedis(): Promise<boolean> {
 }
 
 export async function GET() {
-  const [db, redis] = await Promise.all([checkDb(), checkRedis()]);
+  const [db, redis, horizon] = await Promise.all([checkDb(), checkRedis(), checkHorizonHealth()]);
 
   const healthy = db && redis;
   const poolStats = getPoolStats();
@@ -35,6 +36,7 @@ export async function GET() {
       status: healthy ? "ok" : "degraded",
       db: db ? "ok" : "error",
       redis: redis ? "ok" : "error",
+      horizon: horizon ? "ok" : "error",
       pool: poolStats
         ? {
             total: poolStats.totalCount,

--- a/src/components/circle/CreateCircleForm.tsx
+++ b/src/components/circle/CreateCircleForm.tsx
@@ -160,6 +160,16 @@ export function CreateCircleForm() {
         {errors.circleType && <p className={styles.fieldError}>{errors.circleType.message}</p>}
       </div>
 
+      <div className="input-group">
+        <label className="input-label" htmlFor="payoutMethod">Payout Order</label>
+        <select id="payoutMethod" className="input" {...register("payoutMethod")}>
+          <option value="fixed">Fixed (first-come-first-served)</option>
+          <option value="randomized">Randomized (locked when circle fills)</option>
+        </select>
+        <small className="input-hint">Randomized order is locked and visible to all members once the circle is full.</small>
+        {errors.payoutMethod && <p className={styles.fieldError}>{errors.payoutMethod.message}</p>}
+      </div>
+
       {error && <p className={styles.error} role="alert">{error}</p>}
 
       <Button type="submit" fullWidth loading={isSubmitting} disabled={isSubmitting}>Create Circle</Button>

--- a/src/components/circle/MemberPayoutList.tsx
+++ b/src/components/circle/MemberPayoutList.tsx
@@ -41,12 +41,23 @@ export function MemberPayoutList({ circle, initialMembers, isCreator, currentUse
         <h2 className={styles.title}>
           Payout Order <span className={styles.count}>({members.length})</span>
         </h2>
-        {isCreator && circle.status === "open" && (
+        {isCreator && circle.status === "open" && circle.payoutMethod !== "randomized" && (
           <Button variant="ghost" size="sm" onClick={handleShuffle} loading={shuffling}>
             🔀 Randomize
           </Button>
         )}
       </div>
+
+      {circle.payoutMethod === "randomized" && circle.randomizationSeed && (
+        <p style={{ fontSize: "0.75rem", color: "var(--color-text-muted)", marginBottom: "0.5rem", wordBreak: "break-all" }}>
+          🔒 Order locked · Seed: <code>{circle.randomizationSeed}</code>
+        </p>
+      )}
+      {circle.payoutMethod === "randomized" && !circle.randomizationSeed && (
+        <p style={{ fontSize: "0.75rem", color: "var(--color-text-muted)", marginBottom: "0.5rem" }}>
+          🎲 Order will be randomized and locked when the circle fills.
+        </p>
+      )}
 
       {error && <p className={styles.error}>{error}</p>}
 

--- a/src/lib/stellar.ts
+++ b/src/lib/stellar.ts
@@ -11,11 +11,35 @@ import {
 import { serverConfig } from "@/server/config";
 import logger from "@/lib/logger";
 
+function makeServer(url: string) { return new Horizon.Server(url); }
 
-const server = new Horizon.Server(serverConfig.stellar.horizonUrl);
+const primaryServer = makeServer(serverConfig.stellar.horizonUrl);
+const fallbackServer = serverConfig.stellar.horizonFallbackUrl
+  ? makeServer(serverConfig.stellar.horizonFallbackUrl)
+  : null;
+
+/** Returns the active Horizon server, failing over to secondary on error. */
+async function withFallback<T>(fn: (s: Horizon.Server) => Promise<T>): Promise<T> {
+  try {
+    return await fn(primaryServer);
+  } catch (err) {
+    if (!fallbackServer) throw err;
+    logger.warn({ err, fallback: serverConfig.stellar.horizonFallbackUrl }, "[stellar] Primary Horizon failed, switching to fallback");
+    return fn(fallbackServer);
+  }
+}
+
+export async function checkHorizonHealth(): Promise<boolean> {
+  try { await withFallback((s) => s.loadAccount("GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN")); return true; }
+  catch { return false; }
+}
+
 const USDC = new Asset(serverConfig.usdc.assetCode, serverConfig.usdc.issuer);
 const networkPassphrase =
   serverConfig.stellar.network === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
+
+// Keep backward-compat export
+const server = primaryServer;
 
 type StellarBalance = {
   asset_type: string;
@@ -82,12 +106,11 @@ function isRetryable(err: any): boolean {
  */
 export async function sendUsdcPayment(destination: string, amount: string): Promise<string> {
   const keypair = Keypair.fromSecret(serverConfig.stellar.serverSecretKey);
-  const MAX_ATTEMPTS = 4; // Initial attempt + 3 retries
+  const MAX_ATTEMPTS = 4;
 
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     try {
-      // Fetch fresh account (and sequence number) on every attempt to prevent stale sequences
-      const account = await server.loadAccount(keypair.publicKey());
+      const account = await withFallback((s) => s.loadAccount(keypair.publicKey()));
 
       const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase })
         .addOperation(Operation.payment({ destination, asset: USDC, amount }))
@@ -95,7 +118,7 @@ export async function sendUsdcPayment(destination: string, amount: string): Prom
         .build();
 
       tx.sign(keypair);
-      const result = await server.submitTransaction(tx);
+      const result = await withFallback((s) => s.submitTransaction(tx));
       
       if (attempt > 1) {
         logger.info({ attempt, destination, hash: result.hash }, "[stellar] sendUsdcPayment succeeded after retry");
@@ -135,7 +158,7 @@ export async function getUsdcBalance(
   publicKey: string
 ): Promise<{ balance: string; hasTrustline: boolean }> {
   try {
-    const account = await server.loadAccount(publicKey);
+    const account = await withFallback((s) => s.loadAccount(publicKey));
     const bal = account.balances.find(
       (b) =>
         b.asset_type !== "native" &&
@@ -158,7 +181,7 @@ export async function validateStellarRecipient(publicKey: string): Promise<void>
 
   let account: StellarAccountWithBalances;
   try {
-    account = await server.loadAccount(publicKey);
+    account = await withFallback((s) => s.loadAccount(publicKey));
   } catch {
     throw new Error(`Stellar account not found on-chain: ${publicKey}`);
   }

--- a/src/server/config/index.ts
+++ b/src/server/config/index.ts
@@ -6,6 +6,7 @@ export const serverConfig = {
   stellar: {
     network: (process.env.STELLAR_NETWORK ?? "testnet") as "testnet" | "mainnet",
     horizonUrl: process.env.STELLAR_HORIZON_URL ?? "https://horizon-testnet.stellar.org",
+    horizonFallbackUrl: process.env.STELLAR_HORIZON_FALLBACK_URL ?? "",
     networkPassphrase:
       process.env.STELLAR_NETWORK_PASSPHRASE ?? "Test SDF Network ; September 2015",
     ajoContractId: process.env.STELLAR_AJO_CONTRACT_ID ?? "",

--- a/src/server/services/circle.service.ts
+++ b/src/server/services/circle.service.ts
@@ -225,6 +225,24 @@ export async function joinCircle(
          WHERE id=$2`,
         [computeNextPayoutDate(circle.cycleFrequency), circleId]
       );
+
+      // Auto-randomize order when circle is full if randomize_order was selected
+      if (circle.payoutMethod === "randomized" && !circle.randomizationSeed) {
+        const { randomBytes } = await import("crypto");
+        const seed = `${Date.now()}-${randomBytes(16).toString("hex")}`;
+        // Fetch all active member ids for shuffling
+        const allActive = [...memberRows.filter(m => m.status === 'active'), newMember[0]];
+        const positions = allActive.map((_, i) => i + 1);
+        const seededRandom = createSeededRandom(seed);
+        for (let i = positions.length - 1; i > 0; i--) {
+          const j = Math.floor(seededRandom() * (i + 1));
+          [positions[i], positions[j]] = [positions[j], positions[i]];
+        }
+        for (let i = 0; i < allActive.length; i++) {
+          await q("UPDATE members SET position = $1, updated_at = NOW() WHERE id = $2", [positions[i], allActive[i].id]);
+        }
+        await q("UPDATE circles SET randomization_seed = $1, updated_at = NOW() WHERE id = $2", [seed, circleId]);
+      }
     }
 
     return newMember[0];

--- a/src/server/services/payout.service.ts
+++ b/src/server/services/payout.service.ts
@@ -6,8 +6,26 @@ import { withPayoutLock, PayoutLockError } from "./payout-lock";
 import { notifyPayoutProcessed, notifyCircleCompleted } from "./notification.service";
 import type { Payout } from "@/types";
 import { randomUUID } from "crypto";
+import logger from "@/lib/logger";
 
 export { PayoutLockError };
+
+const PAYOUT_MAX_RETRIES = 3;
+const RETRY_DELAY_MS = [5_000, 15_000, 45_000];
+
+async function alertAdmin(circleId: string, cycle: number, error: string) {
+  const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+  if (!webhookUrl) return;
+  try {
+    await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: `🚨 Payout failed after all retries — circle: ${circleId}, cycle: ${cycle}\nError: ${error}` }),
+    });
+  } catch (e) {
+    logger.error({ e }, "[payout] Failed to send admin alert");
+  }
+}
 
 /**
  * Process a payout cycle for a circle.
@@ -29,49 +47,85 @@ export async function processCyclePayout(
     if (circle.status !== "active") throw new Error("Circle is not active");
 
     const circleMembers = await getMembersByCircle(circleId);
-    // Only count active members (exclude defaulted) for the pot
     const activeMembers = circleMembers.filter((m) => m.status === "active");
     const totalPot = (
       parseFloat(circle.contributionUsdc) * activeMembers.length
     ).toFixed(7);
 
-    // Guard: reject if the current cycle's recipient already received a payout
     const recipientMemberForGuard = circleMembers[circle.currentCycle - 1];
     if (recipientMemberForGuard?.hasReceivedPayout) {
       throw new Error(`Member has already received payout for cycle ${circle.currentCycle}`);
-    }
-
-    let txHash: string;
-    if (circle.contractId) {
-      // Soroban path: contract handles transfer, backend only triggers payout()
-      txHash = await invokeContractPayout(circle.contractId);
-    } else {
-      // Horizon fallback: validate key, account existence, and USDC trustline first
-      await validateStellarRecipient(recipientStellarKey);
-      txHash = await sendUsdcPayment(recipientStellarKey, totalPot);
     }
 
     const payoutId = randomUUID();
     const recipientMember = circleMembers[circle.currentCycle - 1];
     const recipientMemberId = recipientMember?.id ?? "";
 
-    // Atomically persist the payout record and mark the member as paid.
-    // The UNIQUE constraint on (circle_id, cycle_number) provides a second
-    // layer of idempotency at the database level — a duplicate call for the
-    // same cycle will fail with a unique-violation error before any money moves.
+    // Insert payout record as 'pending' before attempting
+    await query(
+      `INSERT INTO payouts (id, circle_id, recipient_member_id, cycle_number, amount_usdc, tx_hash, status, retry_count, paid_at)
+       VALUES ($1, $2, $3, $4, $5, '', 'pending', 0, NOW())
+       ON CONFLICT (circle_id, cycle_number) DO NOTHING`,
+      [payoutId, circleId, recipientMemberId, circle.currentCycle, totalPot]
+    );
+
+    // Fetch the actual record (handles idempotency if already inserted)
+    const { rows: existingRows } = await query<Payout & { status: string; retry_count: number }>(
+      `SELECT id, status, retry_count FROM payouts WHERE circle_id = $1 AND cycle_number = $2`,
+      [circleId, circle.currentCycle]
+    );
+    const existingPayout = existingRows[0];
+    if (existingPayout?.status === "completed") {
+      throw new Error(`Payout for cycle ${circle.currentCycle} has already been processed`);
+    }
+
+    const currentRetry = existingPayout?.retry_count ?? 0;
+    let txHash: string;
+    let lastError = "";
+
+    for (let attempt = 0; attempt <= PAYOUT_MAX_RETRIES; attempt++) {
+      if (attempt > 0) {
+        await new Promise((r) => setTimeout(r, RETRY_DELAY_MS[attempt - 1]));
+      }
+      try {
+        if (circle.contractId) {
+          txHash = await invokeContractPayout(circle.contractId);
+        } else {
+          await validateStellarRecipient(recipientStellarKey);
+          txHash = await sendUsdcPayment(recipientStellarKey, totalPot);
+        }
+        lastError = "";
+        break;
+      } catch (err) {
+        lastError = err instanceof Error ? err.message : String(err);
+        logger.warn({ err, attempt, circleId }, `[payout] attempt ${attempt + 1} failed`);
+        await query(
+          `UPDATE payouts SET status = 'processing', retry_count = $1, last_error = $2 WHERE circle_id = $3 AND cycle_number = $4`,
+          [currentRetry + attempt + 1, lastError, circleId, circle.currentCycle]
+        );
+        if (attempt === PAYOUT_MAX_RETRIES) {
+          await query(
+            `UPDATE payouts SET status = 'failed' WHERE circle_id = $1 AND cycle_number = $2`,
+            [circleId, circle.currentCycle]
+          );
+          await alertAdmin(circleId, circle.currentCycle, lastError);
+          throw err;
+        }
+      }
+    }
+
     let payout: Payout;
     try {
       payout = await transaction(async (q) => {
         const { rows } = await q<Payout>(
-          `INSERT INTO payouts (id, circle_id, recipient_member_id, cycle_number, amount_usdc, tx_hash, paid_at)
-           VALUES ($1, $2, $3, $4, $5, $6, NOW())
+          `UPDATE payouts
+           SET tx_hash = $1, status = 'completed', paid_at = NOW()
+           WHERE circle_id = $2 AND cycle_number = $3
            RETURNING id, circle_id as "circleId", recipient_member_id as "recipientMemberId",
                      cycle_number as "cycleNumber", amount_usdc as "amountUsdc", tx_hash as "txHash", paid_at as "paidAt"`,
-          [payoutId, circleId, recipientMemberId, circle.currentCycle, totalPot, txHash]
+          [txHash!, circleId, circle.currentCycle]
         );
 
-        // Mark recipient as having received their payout within the same transaction
-        // so the flag is always consistent with the payout record.
         if (recipientMemberId) {
           await q(
             "UPDATE members SET has_received_payout = TRUE, updated_at = NOW() WHERE id = $1",
@@ -82,7 +136,6 @@ export async function processCyclePayout(
         return rows[0];
       });
     } catch (err: unknown) {
-      // Surface duplicate-cycle violations as a clean application error
       const pg = err as { code?: string };
       if (pg.code === "23505") {
         throw new Error(`Payout for cycle ${circle.currentCycle} has already been processed`);


### PR DESCRIPTION
closes #312 - Freighter wallet connect already wired in profile page;
       ensured ConnectWalletButton renders for all non-installed states

closes #327 - Add Horizon fallback (STELLAR_HORIZON_FALLBACK_URL) with automatic
       failover on error; Horizon health check added to /api/v1/health

closes #332 - Payout status tracking (pending/processing/completed/failed);
       retry up to 3 times with backoff; admin alert via Slack on exhaustion;
       manual retry endpoint POST /api/admin/payouts/[id]/retry;
       migration 1748600000000_add-payout-status.ts

closes #331 - randomize_order via payoutMethod field (already in schema);
       auto-shuffle + seed locked when circle fills in joinCircle;
       CreateCircleForm exposes Payout Order dropdown;
       MemberPayoutList shows seed for verifiability and hides manual
       shuffle button when randomized mode is active

## Summary

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs
- [ ] Smart contract change

## Related issues
Closes #

## Checklist
- [ ] Tests pass (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Types pass (`npm run type-check`)
- [ ] Contract tests pass (`npm run contract:test`) if applicable
- [ ] No secrets committed
