### PR TITLE
feat: Paystack webhook failed-payment handler, sitemap.xml, and robots.txt

### DIFF
--- a/src/app/api/webhooks/paystack/__tests__/route.test.ts
+++ b/src/app/api/webhooks/paystack/__tests__/route.test.ts
@@ -91,4 +91,16 @@ describe("POST /api/webhooks/paystack", () => {
     expect(json.duplicate).toBe(true);
     expect(mockQuery).toHaveBeenCalledTimes(1);
   });
+
+  it("marks contribution as failed on charge.failed", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 } as any);
+
+    const req = makeRequest({ event: "charge.failed", data: { reference: "ajo-circle-1-member-1-2" } });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("status = 'failed'"),
+      ["ajo-circle-1-member-1-2"]
+    );
+  });
 });

--- a/src/app/api/webhooks/paystack/route.ts
+++ b/src/app/api/webhooks/paystack/route.ts
@@ -24,6 +24,19 @@ export async function POST(req: NextRequest) {
 
   const event = JSON.parse(rawBody);
 
+  if (event.event === "charge.failed") {
+    const reference: string = event.data?.reference;
+    if (!reference) {
+      return NextResponse.json({ error: "Missing reference" }, { status: 400 });
+    }
+    await query(
+      `UPDATE contributions SET status = 'failed'
+       WHERE paystack_reference = $1 AND status = 'pending'`,
+      [reference]
+    );
+    return NextResponse.json({ received: true });
+  }
+
   if (event.event !== "charge.success") {
     return NextResponse.json({ received: true });
   }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,14 @@
+import { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/api/", "/dashboard/"],
+      },
+    ],
+    sitemap: "https://www.ajosave.app/sitemap.xml",
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,25 @@
+import { MetadataRoute } from "next";
+import { query } from "@/lib/db";
+
+const BASE_URL = "https://www.ajosave.app";
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const { rows } = await query<{ id: string; updated_at: string }>(
+    `SELECT id, updated_at FROM circles WHERE circle_type = 'public' AND status = 'open' ORDER BY created_at DESC`
+  );
+
+  const circleUrls: MetadataRoute.Sitemap = rows.map((circle) => ({
+    url: `${BASE_URL}/circles/${circle.id}`,
+    lastModified: new Date(circle.updated_at),
+    changeFrequency: "daily",
+    priority: 0.7,
+  }));
+
+  return [
+    { url: BASE_URL, lastModified: new Date(), changeFrequency: "weekly", priority: 1 },
+    { url: `${BASE_URL}/circles`, lastModified: new Date(), changeFrequency: "hourly", priority: 0.9 },
+    { url: `${BASE_URL}/faq`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.5 },
+    { url: `${BASE_URL}/help`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.5 },
+    ...circleUrls,
+  ];
+}


### PR DESCRIPTION
## Summary

- **#288** — Added `charge.failed` event handling to the Paystack webhook route, updating the contribution status to `failed`. Added integration test covering this case.
- **#321** — Added `sitemap.ts` (Next.js App Router) that dynamically generates `sitemap.xml` including all public open circles. Added `robots.ts` that disallows `/api/` and `/dashboard/` and points to the sitemap.

## Changes

- `src/app/api/webhooks/paystack/route.ts` — handle `charge.failed` events
- `src/app/api/webhooks/paystack/__tests__/route.test.ts` — test for failed payment status update
- `src/app/sitemap.ts` — dynamic sitemap with public circle pages
- `src/app/robots.ts` — robots.txt disallowing api/dashboard

Closes #288
Closes #321